### PR TITLE
cr_checker: Fix lib target path in macro

### DIFF
--- a/cr_checker/MODULE.bazel
+++ b/cr_checker/MODULE.bazel
@@ -13,7 +13,7 @@
 
 module(
     name = "cr_checker",
-    version = "0.1.0",
+    version = "0.1.1",
     compatibility_level = 0,
 )
 

--- a/cr_checker/cr_checker.bzl
+++ b/cr_checker/cr_checker.bzl
@@ -93,7 +93,7 @@ def copyright_checker(
             name = t_name,
             main = "cr_checker.py",
             srcs = [
-                "//tool:cr_checker_lib",
+                "@cr_checker//tool:cr_checker_lib",
             ],
             args = args,
             data = srcs + [


### PR DESCRIPTION
Target namespace for cr_checker_lib path in macro must start with namespace to be accessable in upper Bazel modules.