### PR TITLE
cr_checker: Change the name of module

### DIFF
--- a/cr_checker/MODULE.bazel
+++ b/cr_checker/MODULE.bazel
@@ -12,8 +12,8 @@
 # *******************************************************************************
 
 module(
-    name = "cr_checker",
-    version = "0.1.1",
+    name = "score_cr_checker",
+    version = "0.2.0",
     compatibility_level = 0,
 )
 

--- a/cr_checker/cr_checker.bzl
+++ b/cr_checker/cr_checker.bzl
@@ -93,7 +93,7 @@ def copyright_checker(
             name = t_name,
             main = "cr_checker.py",
             srcs = [
-                "@cr_checker//tool:cr_checker_lib",
+                "@score_cr_checker//tool:cr_checker_lib",
             ],
             args = args,
             data = srcs + [


### PR DESCRIPTION
To be consistent with other modules, we added prefix score to the module name. The new name is now `score_cr_checker`.