### PR TITLE
bazel: Add cr_checker alias

### DIFF
--- a/cr_checker/MODULE.bazel
+++ b/cr_checker/MODULE.bazel
@@ -13,7 +13,7 @@
 
 module(
     name = "score_cr_checker",
-    version = "0.2.1",
+    version = "0.2.2",
     compatibility_level = 0,
 )
 

--- a/cr_checker/README.md
+++ b/cr_checker/README.md
@@ -181,5 +181,5 @@ This will allow Bazel to look into project Bazel registry. After that all what i
 # CopyRight checker dependencies
 #
 ###############################################################################
-bazel_dep(name = "score_cr_checker", version = "0.2.1")
+bazel_dep(name = "score_cr_checker", version = "0.2.2")
 ```

--- a/cr_checker/cr_checker.bzl
+++ b/cr_checker/cr_checker.bzl
@@ -102,3 +102,9 @@ def copyright_checker(
             ],
             visibility = visibility,
         )
+
+    native.alias(
+        name = "copyright-check",
+        actual = ":" + name + ".check",
+        visibility = visibility,
+    )


### PR DESCRIPTION
Created alias that allows standardized target call: bazel run copyright-check

Related: [#737](https://github.com/eclipse-score/score/issues/737)