### PR TITLE
dash: decouple from score repo

### DIFF
--- a/dash/LICENSE
+++ b/dash/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2025 Contributors to the Eclipse Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/dash/MODULE.bazel
+++ b/dash/MODULE.bazel
@@ -13,7 +13,7 @@
 
 module(
     name = "dash_license_checker",
-    version = "1.1.0",
+    version = "0.1.0",
     compatibility_level = 0,
 )
 

--- a/dash/MODULE.bazel
+++ b/dash/MODULE.bazel
@@ -1,0 +1,36 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+module(
+    name = "dash_license_checker",
+    version = "1.1.0",
+    compatibility_level = 0,
+)
+
+# dependency on rules_java.
+bazel_dep(name = "rules_java", version = "5.0.0") 
+
+
+http_jar = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
+
+DASH_VERSION = "1.1.0"
+
+http_jar(
+    name = "dash_license_tool",
+    sha256 = "ba4e84e1981f0e51f92a42ec8fc8b9668dabb08d1279afde46b8414e11752b06",
+    urls = [
+        "https://repo.eclipse.org/content/repositories/dash-licenses/org/eclipse/dash/org.eclipse.dash.licenses/{version}/org.eclipse.dash.licenses-{version}.jar".format(version = DASH_VERSION),
+    ],
+)
+
+

--- a/dash/README.md
+++ b/dash/README.md
@@ -7,7 +7,7 @@ This directory provides Bazel build configurations and custom rules to integrate
 ```bash
 ├── BUILD
 ├── dash.bzl
-├── formatters
+├── tool/formatters
 │   ├── BUILD
 │   ├── dash_format_converter.bzl
 │   └── dash_format_converter.py
@@ -25,19 +25,20 @@ This directory provides Bazel build configurations and custom rules to integrate
 - Contains the dash_license_checker macro, which defines a `java_binary` target to run the DASH license checker.
 - Loads `dash_format_converter.bzl` from the `formatters` package to preprocess requirement files.
 - Converts the input `requirements_lock.txt` file into a format compatible with the DASH license tool before invoking the Java-based checker.
+- Converts also Cargo.lock inputs intp a format compatible with the DASH license tool
 
-**formatters/BUILD**
+**tool/formatters/BUILD**
 
 - Empty file indicating that formatters is a Bazel package.
 
-**formatters/dash_format_converter.bzl**
+**tool/formatters/dash_format_converter.bzl**
 
 - Defines a custom Bazel rule `dash_format_converter`.
-- Calls `dash_format_converter.py` to transform `requirements_lock.txt` into a format that the DASH tool can process.
+- Calls `dash_format_converter.py` to transform `requirements_lock.txt`  or `Cargo.lock` into a format that the DASH tool can process.
 
-**formatters/dash_format_converter.py**
+**tool/formatters/dash_format_converter.py**
 
-- Implements the logic to convert `requirements_lock.`txt into a format accepted by the DASH license checker.
+- Implements the logic to convert the input into a format accepted by the DASH license checker.
 - This script is executed as part of the `dash_format_converter` Bazel rule.
 
 ## Usage
@@ -45,7 +46,7 @@ This directory provides Bazel build configurations and custom rules to integrate
 To integrate the DASH license checker into your Bazel project, define a target in your `BUILD` file as follows:
 
 ```bash
-load("//tools/dash:dash.bzl", "dash_license_checker")
+load("@dash_license_checker//:dash.bzl", "dash_license_checker")
 
 dash_license_checker(
     name = "my_project_license_check",
@@ -83,38 +84,3 @@ dash_license_checker(
 
 ```
 
-## Local vs. CI Execution
-
-### Local Development
-
-By default, simply run:
-
-```bash
-bazel run //tools/dash:license.check.my_project_license_check
-```
-
-If we're not enabling review mode (no --define=CI_BUILD=true), the checker will parse
-the dependencies without requiring an authentication token or performing any “review” logic.
-
-
-### CI Integration
-
-In the Continuous Integration (CI) pipeline  we'll typically:
-
-Pass `--define=CI_BUILD=true` to enable review mode (via a select() in the BUILD file).
-Supply additional parameters (like -token, -project, -repo) at runtime after the double dash (--).
-
-
-- `--define=CI_BUILD=true` triggers your macro to append `-review` (if configured).
-- `-project`, `-repo`, and `-token` are passed directly to the resulting Java process at runtime.
-All secrets (like the token) are injected from the GitHub Actions environment or repository secrets
-and **never stored in Bazel’s BUILD files**.
-
-
-### Security Considerations
-- **Token passing**: Always supply tokens and other secrets at runtime
-(-token "${{ secrets.ECLIPSE_GITLAB_API_TOKEN }}") rather than hardcoding them in BUILD files.
-
-- **review mode**: Typically only enabled in CI, since we individual developers won't be granted access tokens
-
-- **Hermetic builds**: The build remains hermetic and consistent, while secrets are introduced only at runtime.

--- a/dash/README.md
+++ b/dash/README.md
@@ -1,0 +1,120 @@
+# DASH License Checker Bazel Integration
+
+This directory provides Bazel build configurations and custom rules to integrate the DASH license checker into projects. The setup includes a macro to define a java_binary target for license validation and a custom rule for converting requirement files into the appropriate DASH format.
+
+## Directory Structure
+
+```bash
+├── BUILD
+├── dash.bzl
+├── formatters
+│   ├── BUILD
+│   ├── dash_format_converter.bzl
+│   └── dash_format_converter.py
+└── README.md
+```
+
+### File Descriptions
+
+**BUILD**
+
+- This file is empty and serves only to mark this directory as a Bazel package.
+
+**dash.bzl**
+
+- Contains the dash_license_checker macro, which defines a `java_binary` target to run the DASH license checker.
+- Loads `dash_format_converter.bzl` from the `formatters` package to preprocess requirement files.
+- Converts the input `requirements_lock.txt` file into a format compatible with the DASH license tool before invoking the Java-based checker.
+
+**formatters/BUILD**
+
+- Empty file indicating that formatters is a Bazel package.
+
+**formatters/dash_format_converter.bzl**
+
+- Defines a custom Bazel rule `dash_format_converter`.
+- Calls `dash_format_converter.py` to transform `requirements_lock.txt` into a format that the DASH tool can process.
+
+**formatters/dash_format_converter.py**
+
+- Implements the logic to convert `requirements_lock.`txt into a format accepted by the DASH license checker.
+- This script is executed as part of the `dash_format_converter` Bazel rule.
+
+## Usage
+
+To integrate the DASH license checker into your Bazel project, define a target in your `BUILD` file as follows:
+
+```bash
+load("//tools/dash:dash.bzl", "dash_license_checker")
+
+dash_license_checker(
+    name = "my_project_license_check",
+    src = "//path/to/requirements_lock.txt",
+    visibility = ["//visibility:public"],
+)
+```
+
+This will:
+
+1. Use dash_format_converter to process requirements_lock.txt.
+2. Create a java_binary target that executes the DASH license checker with the converted file.
+3. Ensure compliance with dependency licensing requirements in your project.
+
+
+
+Example to check `RUST` based dependecies:
+
+```bash
+# Needed for Dash tool to check rust dependency licenses.
+filegroup(
+    name = "cargo_lock",
+    srcs = [
+        "_tooling/Cargo.lock",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+dash_license_checker(
+    name = "rust",
+    src = "//docs:cargo_lock",
+    visibility = ["//visibility:public"],
+    file_type = "cargo"
+)
+
+```
+
+## Local vs. CI Execution
+
+### Local Development
+
+By default, simply run:
+
+```bash
+bazel run //tools/dash:license.check.my_project_license_check
+```
+
+If we're not enabling review mode (no --define=CI_BUILD=true), the checker will parse
+the dependencies without requiring an authentication token or performing any “review” logic.
+
+
+### CI Integration
+
+In the Continuous Integration (CI) pipeline  we'll typically:
+
+Pass `--define=CI_BUILD=true` to enable review mode (via a select() in the BUILD file).
+Supply additional parameters (like -token, -project, -repo) at runtime after the double dash (--).
+
+
+- `--define=CI_BUILD=true` triggers your macro to append `-review` (if configured).
+- `-project`, `-repo`, and `-token` are passed directly to the resulting Java process at runtime.
+All secrets (like the token) are injected from the GitHub Actions environment or repository secrets
+and **never stored in Bazel’s BUILD files**.
+
+
+### Security Considerations
+- **Token passing**: Always supply tokens and other secrets at runtime
+(-token "${{ secrets.ECLIPSE_GITLAB_API_TOKEN }}") rather than hardcoding them in BUILD files.
+
+- **review mode**: Typically only enabled in CI, since we individual developers won't be granted access tokens
+
+- **Hermetic builds**: The build remains hermetic and consistent, while secrets are introduced only at runtime.

--- a/dash/dash.bzl
+++ b/dash/dash.bzl
@@ -1,0 +1,103 @@
+# *******************************************************************************
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_java//java:java_binary.bzl", "java_binary")
+load("//tool/formatters:dash_format_converter.bzl", "dash_format_converter")
+
+def dash_license_checker(
+        visibility,
+        src,
+        file_type = "",
+        project_config = None):
+    """
+    Defines a Bazel macro for creating a `java_binary` target that integrates the DASH license checker.
+    The generated target is always named 'license_check', and an alias 'license-check' is automatically
+    created pointing to it.
+
+    Usage (Explicit mode):
+      Provide the 'src' explicitly.
+      
+      If 'file_type' is omitted (empty string) and a project_config is provided, the file_type is
+      determined from the "source_code" field in project_config.
+      
+      Example project_config (project_config.bzl):
+      
+          PROJECT_CONFIG = {
+              "asil_level": "QM",
+              "source_code": ["python"]
+          }
+      
+      - If "python" is present, file_type becomes "requirements".
+      - If "rust" is present, file_type becomes "cargo".
+    
+    Example usage:
+    
+         dash_license_checker(
+             visibility = ["//visibility:public"],
+             src = "//docs:requirements",  # a filegroup target pointing to your requirements.txt file
+             file_type = "",                # omitted so that it's determined from project_config
+             project_config = PROJECT_CONFIG
+         )
+    """
+    name = "license_check"
+
+    # Determine file_type from project_config if not provided.
+    if file_type == "":
+        if project_config != None:
+            languages = project_config.get("source_code", [])
+            if "python" in languages:
+                file_type = "requirements"
+            elif "rust" in languages:
+                file_type = "cargo"
+            else:
+                fail("Unsupported project type in project_config: {}".format(languages))
+        else:
+            fail("file_type is not provided and no project_config was passed to determine it.")
+
+    if src == "":
+        fail("You must provide the src explicitly.")
+
+    # Convert the dependency file using the provided file_type.
+    dash_format_converter(
+        name = "{}2dash".format(name),
+        requirement_file = src,
+        file_type = file_type,
+    )
+
+    # Create the java_binary target that runs the license checker.
+    java_binary(
+        name = "license.check.{}".format(name),
+        main_class = "org.eclipse.dash.licenses.cli.Main",
+        runtime_deps = [
+            "@dash_license_tool//jar",
+        ],
+        # We'll build up "args" in the order: [ static options ] + [ file last ]
+        args = [
+                   # If we have any always-on flags, put them here
+               ] +
+               [
+                   # The file is last
+                   "$(location :{}2dash)".format(name),
+               ],
+        data = [
+            ":{}2dash".format(name),
+        ],
+        visibility = ["//visibility:public"],
+    )
+
+    # Automatically create an alias "license-check" that points to the java_binary target.
+    native.alias(
+        name = "license-check",
+        actual = ":license.check.{}".format(name),
+        visibility = visibility,
+    )

--- a/dash/tool/formatters/BUILD
+++ b/dash/tool/formatters/BUILD
@@ -1,0 +1,27 @@
+# *******************************************************************************
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+py_library(
+    name = "dash_format_converter_lib",
+    srcs = ["dash_format_converter.py"],
+    visibility = ["//visibility:public"],
+)
+
+py_binary(
+    name = "dash_format_converter",
+    srcs = [
+        "dash_format_converter.py",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [":dash_format_converter_lib"],
+)

--- a/dash/tool/formatters/dash_format_converter.bzl
+++ b/dash/tool/formatters/dash_format_converter.bzl
@@ -1,0 +1,56 @@
+# *******************************************************************************
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+""" Bazel rule for generating dash formatted requirements file
+"""
+
+def _impl(ctx):
+    """ The implementation function of the rule.
+    """
+
+    output = ctx.actions.declare_file("formatted.txt")
+    args = ctx.actions.args()
+    args.add("-i", ctx.file.requirement_file)
+    args.add("-o", output)
+    args.add("-t", ctx.attr.file_type)
+
+    ctx.actions.run(
+        inputs = [ctx.file.requirement_file],
+        outputs = [output],
+        arguments = [args],
+        progress_message = "Generating Dash formatted dependency file ...",
+        mnemonic = "DashFormat",
+        executable = ctx.executable._tool,
+    )
+    return DefaultInfo(files = depset([output]))
+
+dash_format_converter = rule(
+    implementation = _impl,
+    attrs = {
+        "requirement_file": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+            doc = "The requirement (requirement_lock.txt) input file which holds deps",
+        ),
+        "file_type": attr.string(
+            default = "requirements",
+            doc = "Type of input file: 'requirements' for requirements.txt or 'cargo' for Cargo.lock",
+        ),
+        "_tool": attr.label(
+            default = Label("//tool/formatters:dash_format_converter"),
+            executable = True,
+            cfg = "exec",
+            doc = "",
+        ),
+    },
+)

--- a/dash/tool/formatters/dash_format_converter.py
+++ b/dash/tool/formatters/dash_format_converter.py
@@ -1,0 +1,307 @@
+# *******************************************************************************
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+"""The tool for converting requirements.txt into dash checker format"""
+
+import argparse
+import logging
+import re
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
+
+LOGGER = logging.getLogger()
+
+COLORS = {
+    "BLUE": "\033[34m",
+    "GREEN": "\033[32m",
+    "YELLOW": "\033[33m",
+    "RED": "\033[31m",
+    "DARK_RED": "\033[35;1m",
+    "ENDC": "\033[0m",
+}
+
+LOGGER_COLORS = {
+    "DEBUG": COLORS["BLUE"],
+    "INFO": COLORS["GREEN"],
+    "WARNING": COLORS["YELLOW"],
+    "ERROR": COLORS["RED"],
+    "CRITICAL": COLORS["DARK_RED"],
+}
+
+
+class ColoredFormatter(logging.Formatter):
+    """
+    A custom logging formatter to add color to log level names
+    based on the logging level.
+
+    The `ColoredFormatter` class extends `logging.Formatter` and overrides the `format`
+    method to add color codes to the log level name (e.g., `INFO`, `WARNING`, `ERROR`)
+    based on a predefined color mapping in `LOGGER_COLORS`. This color coding helps in
+    visually distinguishing log messages by severity.
+
+    Attributes:
+        LOGGER_COLORS (dict): A dictionary mapping log level names
+                              (e.g., "INFO", "ERROR") to their respective color codes.
+        COLORS (dict): A dictionary of terminal color codes, including an "ENDC" key
+                       to reset colors after the level name.
+
+    Methods:
+        format(record): Adds color to the `levelname` attribute of the log record and
+                        then formats the record as per the superclass `Formatter`.
+    """
+
+    def format(self, record):
+        log_color = LOGGER_COLORS.get(record.levelname, "")
+        record.levelname = f"{log_color}{record.levelname}:{COLORS['ENDC']}"
+        return super().format(record)
+
+
+def configure_logging(log_file_path: Path | None = None, verbose: bool = False) -> None:
+    """
+    Configures the logging settings for the application.
+
+    Args:
+        log_file_path (Path, optional): The file path where logs should be written.
+            If not provided, logs are written to the console. Defaults to `None`.
+        verbose (bool, optional): A flag that determines the logging level.
+            If `True`, sets the logging level to DEBUG; if `False`, sets it to INFO.
+            Defaults to `False`.
+
+    Returns:
+        None: This function does not return any value, it only configures logging.
+
+    Notes:
+        - If `log_file_path` is provided, the log messages will be saved
+          to the specified file.
+        - If `verbose` is `True`, detailed logs (DEBUG level) will be captured;
+          otherwise, less detailed logs (INFO level) will be captured.
+        - The default logging format is:
+          `%(asctime)s - %(name)s - %(levelname)s - %(message)s`.
+    """
+    log_level = logging.DEBUG if verbose else logging.INFO
+    LOGGER.setLevel(log_level)
+    LOGGER.handlers.clear()
+
+    if log_file_path is not None:
+        handler = logging.FileHandler(log_file_path)
+        formatter = logging.Formatter("%(levelname)s: %(message)s")
+    else:
+        handler = logging.StreamHandler()
+        formatter = ColoredFormatter("%(levelname)s %(message)s")
+
+    handler.setLevel(log_level)
+    handler.setFormatter(formatter)
+    LOGGER.addHandler(handler)
+
+
+def format_line(
+    line: str, regex: str = r"([a-zA-Z0-9_-]+)==([a-zA-Z0-9.\-_]+)"
+) -> str | None:
+    """
+    Formats a line of text by matching a specified regex pattern and
+    extracting components.
+
+    Args:
+        line (str): The input string to be processed.
+        regex (str, optional): A regular expression pattern to match the input line.
+
+    Returns:
+        Optional[str]: A formatted string based on the regex match
+        if the pattern is found, or None if no match is found.
+
+    Notes:
+        - The function uses the provided regex to capture two components
+          from the input line: the package name and its version.
+        - The formatted string follows the pattern "pypi/pypi/-/{package}/{version}".
+        - If the regex does not match, None is returned.
+    """
+
+    ret = None
+    match = re.match(f"{regex}", line)
+
+    if match:
+        package, version = match.groups()
+        ret = f"pypi/pypi/-/{package}/{version}"
+
+    return ret
+
+
+def convert_to_dash_format(input_file: Path, output_file: Path):
+    """
+    Converts the content of an input to a "dash format" and writes output file.
+
+    The exact transformation applied to the content is assumed to replace specific
+    patterns or structures with a dash-separated format, although the details depend
+    on the implementation.
+
+    Args:
+        input_file (Path): Path to the input file containing the original content.
+        output_file (Path): Path to the output file where the converted content
+                            will be written.
+
+    """
+    encoding = "utf-8"
+    with (
+        open(input_file, encoding=encoding) as infile,
+        open(output_file, "w", encoding=encoding) as outfile,
+    ):
+        for line in infile:
+            formatted_line = format_line(line.strip())
+            if formatted_line:
+                outfile.write(formatted_line + "\n")
+
+
+def convert_cargo_to_dash_format(input_file: Path, output_file: Path) -> int:
+    """
+    Converts a Cargo.lock file into dash format.
+
+    This function parses the TOML-formatted Cargo.lock file, iterates over the package entries,
+    and writes each package's name and version in the format:
+        cargo/cargo/-/{name}/{version}
+    """
+    encoding = "utf-8"
+    try:
+        with open(input_file, "rb") as infile:
+            cargo_data = tomllib.load(infile)
+    except Exception as e:
+        LOGGER.error(f"Error parsing Cargo.lock file: {e}")
+        return 1
+
+    packages = cargo_data.get("package", [])
+
+    if not packages:
+        LOGGER.warning("No packages found in Cargo.lock.")
+
+    with open(output_file, "w", encoding=encoding) as outfile:
+        for pkg in packages:
+            name = pkg.get("name")
+            version = pkg.get("version")
+            if name and version:
+                line = f"cargo/cargo/-/{name}/{version}"
+                LOGGER.debug(f"Extracted package: {line}")
+                outfile.write(line + "\n")
+
+    LOGGER.info(
+        f"Successfully converted {len(packages)} packages from Cargo.lock to {output_file}"
+    )
+
+    return 0
+
+
+def parse_arguments(argv: list[str]) -> argparse.Namespace:
+    """
+    Parses command-line arguments passed to the script.
+
+    Args:
+        argv (list[str]): A list of command-line arguments, typically `sys.argv[1:]`.
+
+    Returns:
+        argparse.Namespace: An object containing the parsed arguments as attributes.
+
+    Notes:
+        - This function expects an `argparse.ArgumentParser` to be configured with
+          the required arguments.
+          If `argv` is not provided, it defaults to an empty list.
+        - Use the `argparse.Namespace` object to access parsed arguments by their names.
+    """
+
+    parser = argparse.ArgumentParser(
+        description="The tool for converting requirements.txt into dash \
+                     checker format."
+    )
+
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable debug logging level",
+    )
+
+    parser.add_argument(
+        "-l",
+        "--log-file",
+        type=Path,
+        default=None,
+        help="Redirect logs from STDOUT to this file",
+    )
+
+    parser.add_argument(
+        "-i",
+        "--input",
+        type=Path,
+        required=True,
+        help="Path to the requirement.txt file",
+    )
+
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        required=True,
+        help="Path to the formatted_list.txt file",
+    )
+
+    parser.add_argument(
+        "-t",
+        "--type",
+        choices=["requirements", "cargo"],
+        default="requirements",
+        help="Type of input file: 'requirements' for requirements.txt or 'cargo' for Cargo.lock (default: requirements)",
+    )
+
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None) -> int:
+    """
+    The main entry point of the script.
+
+    This function parses command-line arguments, configures logging, and dispatches the appropriate
+    conversion function based on the input file type. Supported file types include:
+      - 'requirements': for processing requirements.txt files.
+      - 'cargo': for processing Cargo.lock files.
+    The selected conversion function reads the input file, transforms its content into the Eclipse dash
+    format, and writes the results to the specified output file.
+
+    Args:
+        argv (list[str], optional): A list of command-line arguments. If not provided, defaults to
+            None, in which case sys.argv[1:] is used.
+
+    Returns:
+        int: An exit code where 0 indicates successful execution, and any non-zero value indicates
+            an error occurred during processing.
+
+    Notes:
+        - This function is typically invoked in the 'if __name__ == "__main__":' block.
+        - It orchestrates argument parsing, logging configuration, file conversion, and error handling.
+        - Conversion behavior depends on the '--type' argument:
+            * 'requirements' (default): Converts a requirements.txt file.
+            * 'cargo': Converts a Cargo.lock file using TOML parsing.
+        - Errors during file reading, parsing, or conversion are logged appropriately, and a non-zero
+          exit code is returned to signal failure.
+    """
+    args = parse_arguments(argv if argv is not None else sys.argv[1:])
+    configure_logging(args.log_file, args.verbose)
+    if args.type == "cargo":
+        ret = convert_cargo_to_dash_format(args.input, args.output)
+    else:
+        ret = convert_to_dash_format(args.input, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Move dash to the tooling repo, decoupling it from the score.
Create a native alias. Introduce the concept of a project config file
with properties (optional)

Fixes: #505