### PR TITLE
dash: embedded the DASH license checker into the module

### DIFF
--- a/dash/BUILD
+++ b/dash/BUILD
@@ -1,0 +1,5 @@
+java_import(
+    name = "jar",
+    jars = ["org.eclipse.dash.licenses-1.1.0.jar"],
+    visibility = ["//visibility:public"],
+)

--- a/dash/MODULE.bazel
+++ b/dash/MODULE.bazel
@@ -17,20 +17,4 @@ module(
     compatibility_level = 0,
 )
 
-# dependency on rules_java.
-bazel_dep(name = "rules_java", version = "5.0.0") 
-
-
-http_jar = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
-
-DASH_VERSION = "1.1.0"
-
-http_jar(
-    name = "dash_license_tool",
-    sha256 = "ba4e84e1981f0e51f92a42ec8fc8b9668dabb08d1279afde46b8414e11752b06",
-    urls = [
-        "https://repo.eclipse.org/content/repositories/dash-licenses/org/eclipse/dash/org.eclipse.dash.licenses/{version}/org.eclipse.dash.licenses-{version}.jar".format(version = DASH_VERSION),
-    ],
-)
-
-
+bazel_dep(name = "rules_java", version = "8.6.3")

--- a/dash/dash.bzl
+++ b/dash/dash.bzl
@@ -79,7 +79,7 @@ def dash_license_checker(
         name = "license.check.{}".format(name),
         main_class = "org.eclipse.dash.licenses.cli.Main",
         runtime_deps = [
-            "@dash_license_tool//jar",
+            "@dash_license_checker//:jar",
         ],
         # We'll build up "args" in the order: [ static options ] + [ file last ]
         args = [


### PR DESCRIPTION
Embedded the DASH license checker JAR directly into the dash_license_checker module using java_import. Cleaned up MODULE.bazel and removed the http_jar setup. Updated macro to reference the local :jar target, simplifying usage for consumers — no more separate repo needed.

Addresses: eclipse-score/score#505