### PR TITLE
copyright checker: fix C/C++ template

### DIFF
--- a/cr_checker/resources/templates.ini
+++ b/cr_checker/resources/templates.ini
@@ -12,17 +12,17 @@
 # *******************************************************************************
 [cpp,c,h,hpp]
 /********************************************************************************
-* Copyright (c) {year} Contributors to the Eclipse Foundation
-*
-* See the NOTICE file(s) distributed with this work for additional
-* information regarding copyright ownership.
-*
-* This program and the accompanying materials are made available under the
-* terms of the Apache License Version 2.0 which is available at
-* https://www.apache.org/licenses/LICENSE-2.0
-*
-* SPDX-License-Identifier: Apache-2.0
-********************************************************************************/
+ * Copyright (c) {year} Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 [py,sh,bzl,ini,yml,BUILD,bazel]
 # *******************************************************************************
 # Copyright (c) {year} Contributors to the Eclipse Foundation


### PR DESCRIPTION
Fix the indentation of the C++ copyright template.