### PR TITLE
dash: fix Cargo format

### DIFF
--- a/dash/MODULE.bazel
+++ b/dash/MODULE.bazel
@@ -13,7 +13,7 @@
 
 module(
     name = "score_dash_license_checker",
-    version = "0.1.1",
+    version = "0.1.2",
     compatibility_level = 0,
 )
 

--- a/dash/tool/formatters/dash_format_converter.py
+++ b/dash/tool/formatters/dash_format_converter.py
@@ -191,7 +191,9 @@ def convert_cargo_to_dash_format(input_file: Path, output_file: Path) -> int:
             name = pkg.get("name")
             version = pkg.get("version")
             if name and version:
-                line = f"cargo/cargo/-/{name}/{version}"
+                # Remove leading 'v' if present
+                version = version.lstrip('v')
+                line = f"crate/cratesio/-/{name}/{version}"
                 LOGGER.debug(f"Extracted package: {line}")
                 outfile.write(line + "\n")
 


### PR DESCRIPTION
The ID is not being specified correctly: "Cargo" is the package manager, "Crates" is the software repository. The content ID should be specified using the latter.

e.g., in IPLab issue 21182 cargo/cargo/-/winapi/0.3.9 should be crate/cratesio/-/winapi/0.3.9.

Excerpt from the documenation:

Steps:

Use cargo to generate a dependency list;
Sort the results and remove duplicates;
Remove empty lines;
Remove references to project code;
Map each line to a ClearlyDefined ID; and
Invoke the tool.
Note that "Cargo" is the package manager, but "Crates" is the software repository. The content ID should be specified using the latter (crate/cratesio/...).

The above example skips code from the Eclipse Zenoh project. Anything that is not third-party content can be removed in a similar manner.

Note that, in order to better leverage ClearlyDefined data, the "v" should not be included in the version number. For example, serde_json v1.0.85 becomes crate/cratesio/-/serde_json/1.0.85.

Tested locally

```
dcalavrezo@DC-QORIX:~/sources/module_template$ cat bazel-out/k8-fastbuild/bin/formatted.txt
crate/cratesio/-/aho-corasick/1.1.3
crate/cratesio/-/aliasable/0.1.3
```

Addresses: #32




