### PR TITLE
Add support to inject other pip index

### DIFF
--- a/python_basics/MODULE.bazel
+++ b/python_basics/MODULE.bazel
@@ -36,6 +36,8 @@ use_repo(python)
 
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(
+    envsubst = ["PIP_INDEX_URL"],
+    extra_pip_args = ["--index-url=${PIP_INDEX_URL:-https://pypi.org/simple/}"],
     hub_name = "pip_score_python_basics",
     python_version = PYTHON_VERSION,
     requirements_lock = "//:requirements.txt",
@@ -57,4 +59,3 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1", dev_dependency=True)
 multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")
 multitool.hub(lockfile = "multitool.lock.json")
 use_repo(multitool, "multitool")
-


### PR DESCRIPTION
Prior to this change, python dependencies were only downloaded from the index
defined in requirements.txt. This is a limitation of rules_py, which usually uses
the bazel downloader for python dependencies. However, if a locked
requirements.txt is provided, it directly uses pip to download patches
from the index specified in the file.

Allow specifying custom index URLs through an environment variable.

Similar to eclipse-score/docs-as-code#103.