### PR TITLE
python: add env variables to pytest

### DIFF
--- a/python_basics/score_pytest/README.md
+++ b/python_basics/score_pytest/README.md
@@ -28,6 +28,10 @@ score_py_pytest(
         # Specify optional arguments, ex:
         "--basetemp /tmp/pytest",
     ],
+    env = {
+        # Specify additional environmental variables, ex:
+        "LD_LIBRARY_PATH": "/path/to/dynamic/lib",
+    },
     # Optionally provide pytest.ini file, that will override the default one
     pytest_ini = "//my_pytest:my_pytest_ini",
 

--- a/python_basics/score_pytest/py_pytest.bzl
+++ b/python_basics/score_pytest/py_pytest.bzl
@@ -16,7 +16,7 @@ load("@pip_score_python_basics//:requirements.bzl", "all_requirements")
 load("@rules_python//python:defs.bzl", "py_test")
 
 
-def score_py_pytest(name, srcs, args = [], data = [], deps = [], plugins = [], pytest_ini = None, **kwargs):
+def score_py_pytest(name, srcs, args = [], data = [], deps = [], env = {}, plugins = [], pytest_ini = None, **kwargs):
     pytest_bootstrap = Label("//score_pytest:main.py")
 
     if not pytest_ini:
@@ -46,7 +46,7 @@ def score_py_pytest(name, srcs, args = [], data = [], deps = [], plugins = [], p
         data = [
             pytest_ini,
         ] + data,
-        env = {
+        env = env | {
             "PYTHONDONOTWRITEBYTECODE": "1",
         },
         **kwargs


### PR DESCRIPTION
Add possibility to extend environmental variables directly for test execution.