### PR TITLE
Reduce the boilerplate needed to use score_python_basics

### DIFF
--- a/python_basics/MODULE.bazel
+++ b/python_basics/MODULE.bazel
@@ -37,7 +37,7 @@ use_repo(python)
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(
     hub_name = "pip_score_python_basics",
-    requirements = "//:requirements.txt",
+    requirements_lock = "//:requirements.txt",
     python_version = PYTHON_VERSION,
 )
 use_repo(pip, "pip_score_python_basics")


### PR DESCRIPTION
Reduce the boilerplate needed to use score_python_basics by providing a single-line setup for consumers.

You can consume it now by using: 

```
bazel_dep(name = "score_python_basics", version = "0.3.3")
```

Still, we need to make a new tag, release, and integrate it in bazel_registry then we need to change the imports of this bazel module when it is used 

close: https://github.com/eclipse-score/tooling/issues/44