### PR TITLE
python: fix pytest args order

### DIFF
--- a/python_basics/score_pytest/py_pytest.bzl
+++ b/python_basics/score_pytest/py_pytest.bzl
@@ -34,12 +34,12 @@ def score_py_pytest(name, srcs, args = [], data = [], deps = [], env = {}, plugi
             pytest_bootstrap,
         ] + srcs,
         main = pytest_bootstrap,
-        args = args +
-               ["-c $(location %s)" % pytest_ini] +
+        args = ["-c $(location %s)" % pytest_ini] +
                [
                    "-p no:cacheprovider",
                    "--show-capture=no",
                ] +
+               args +
                plugins +
                ["$(location %s)" % x for x in srcs],
         deps = all_requirements + deps,


### PR DESCRIPTION
Arguments order matter in pytest execution even when they are key-word. When user defines own args in coftest.py in first order correct pytest.ini file needs to be selected which allows setting rootdir.
In current implementation extra arguments are passed first and pytest raises an error with unrecognized parameters.