### PR TITLE
cli_helper: Update to Bazel 9 compatibility

### DIFF
--- a/cli_helper/MODULE.bazel
+++ b/cli_helper/MODULE.bazel
@@ -13,7 +13,7 @@
 
 module(
     name = "score_cli_helper",
-    version = "0.1.2",
+    version = "0.2.0",
     compatibility_level = 0,
 )
 

--- a/cli_helper/tool/cli_help.py
+++ b/cli_helper/tool/cli_help.py
@@ -1,4 +1,4 @@
-import os, re, subprocess, shutil, textwrap, xml.etree.ElementTree as ET
+import os, subprocess, shutil, textwrap, xml.etree.ElementTree as ET
 
 def bazel(*args: str) -> str:
     return subprocess.check_output(["bazel", *args], text=True)
@@ -9,14 +9,17 @@ if ws:
     os.chdir(ws)
 
 # build a single query for all cli_help tags
-ext_labels = bazel("query", "//external:*", "--output=label","--enable_workspace").splitlines()
-ext_names  = {re.match(r"@([^/]+)//", lbl).group(1)
-              for lbl in ext_labels if lbl.startswith("@")}
-patterns   = ["//..."] + [f"@{n}//..." for n in ext_names]
-expr       = " + ".join(f'attr(tags,"cli_help=.*",{p})' for p in patterns)
+expr = 'kind("rule", attr(tags, "cli_help=.*", deps(//...)))'
 
-xml = bazel("query", expr, "--output=xml",
-            "--ui_event_filters=-INFO,-progress", "--noshow_progress","--enable_workspace")
+xml = bazel(
+    "query",
+    expr,
+    "--output=xml",
+    "--keep_going",
+    "--ui_event_filters=-INFO,-progress",
+    "--noshow_progress",
+)
+
 root = ET.fromstring(xml)
 
 # format the output
@@ -28,40 +31,27 @@ for rule in root.iter("rule"):
         continue
 
     tags = [n.get("value") for n in rule.findall("list[@name='tags']/*")]
-    try:
-        desc = next(t for t in tags if t.startswith("cli_help=")).split("=", 1)[1]
-    except StopIteration:
-        continue
-
-    rows.append((label, desc))
-    max_len = max(max_len, len(label))
-
-col_w       = max_len + 2
-term_cols   = shutil.get_terminal_size(fallback=(80, 24)).columns
-descr_width = max(20, term_cols - col_w - 1)
+    for t in tags:
+        if t.startswith("cli_help="):
+            desc = t.split("=", 1)[1]
+            rows.append((label, desc))
+            max_len = max(max_len, len(label))
+            break
 
 # pretty-print
-CYAN= "\033[36m"
+col_w     = (max_len + 2) if rows else 2
+term_cols = shutil.get_terminal_size(fallback=(80, 24)).columns
+descr_w   = max(20, term_cols - col_w - 1)
+
+CYAN = "\033[36m"
 print(f"{CYAN}BAZEL TARGETS:\n")
 
-for label, desc in rows:
-    # keep user-inserted \n
+for label, desc in sorted(rows):
     paragraphs = desc.splitlines()
-    first_para, *rest_paras = paragraphs
-
-    # wrap only the first paragraph
-    wrapped_first = textwrap.wrap(
-        first_para,
-        width=descr_width,
-        break_long_words=False,
-        break_on_hyphens=False,
-    )
-
-    # print first paragraph
+    first, *rest = paragraphs or [""]
+    wrapped_first = textwrap.wrap(first, width=descr_w, break_long_words=False, break_on_hyphens=False) or [""]
     print(f"{label.ljust(col_w)} {wrapped_first[0]}")
     for line in wrapped_first[1:]:
         print(" " * col_w + " " + line)
-
-    # print remaining paragraphs exactly as written
-    for para in rest_paras:
+    for para in rest:
         print(" " * col_w + " " + para)


### PR DESCRIPTION
Replaced the deprecated(starting with bazel 9 unsupported) //external query with a Bzlmod-safe graph query.
Also drops regex.

Closes: https://github.com/eclipse-score/tooling/issues/62 (implements part 2)