### PR TITLE
Remove ":config" variable from  score_virtualenv function

### DIFF
--- a/python_basics/defs.bzl
+++ b/python_basics/defs.bzl
@@ -24,7 +24,7 @@ def score_virtualenv(name = "ide_support", venv_name = ".venv", reqs = [], tags 
     py_venv(
         name = name,
         venv_name = venv_name,
-        deps = all_requirements + reqs + ["@rules_python//python/runfiles"] ,
+        deps = all_requirements + reqs + ["@rules_python//python/runfiles"],
         data = ["@score_tooling//python_basics:pyproject.toml"] + data,
         tags = tags,
     )

--- a/python_basics/defs.bzl
+++ b/python_basics/defs.bzl
@@ -24,7 +24,7 @@ def score_virtualenv(name = "ide_support", venv_name = ".venv", reqs = [], tags 
     py_venv(
         name = name,
         venv_name = venv_name,
-        deps = all_requirements + reqs + [":config", "@rules_python//python/runfiles"],
+        deps = all_requirements + reqs + ["@rules_python//python/runfiles"] ,
         data = ["@score_tooling//python_basics:pyproject.toml"] + data,
         tags = tags,
     )


### PR DESCRIPTION
Remove the ":config" from deps vaiable in score_virtualenv function which was making ide_support fail in docs-as-code