### PR TITLE
fix cli_helper sub-module to use the correct path

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,7 +13,7 @@
 
 module(
     name = "score_tooling",
-    version = "1.0.0",
+    version = "1.0.1",
     compatibility_level = 1,
 )
 

--- a/cli_helper/cli_helper.bzl
+++ b/cli_helper/cli_helper.bzl
@@ -15,7 +15,7 @@ load("@aspect_rules_py//py:defs.bzl", "py_binary")
 def cli_helper(name, visibility):
     py_binary(
         name = name,
-        srcs = ["@score_cli_helper//tool:cli_help_lib"],
+        srcs = ["@score_tooling//cli_helper/tool:cli_help_lib"],
         visibility = visibility,
     )
 


### PR DESCRIPTION
Fix cli_helper sub-module to use the correct path

close: https://github.com/eclipse-score/tooling/issues/72