### PR TITLE
make pytest hide sphinx deprecation warnings

### DIFF
--- a/python_basics/score_pytest/pytest.ini
+++ b/python_basics/score_pytest/pytest.ini
@@ -38,4 +38,19 @@ norecursedirs =
 
 junit_duration_report = call
 junit_family = xunit1
-filterwarnings = ignore::pytest.PytestExperimentalApiWarning
+filterwarnings =
+    ignore::pytest.PytestExperimentalApiWarning
+
+    # Silence third-party deprecations from sphinx_needs targeting Python 3.14 removals.
+    # We'll drop these ignores once sphinx_needs releases a fix.
+    ignore:.*deprecated.*Python 3\.14.*:DeprecationWarning:sphinx_needs\..*
+
+    # Docutils is deprecating OptionParser in favor of argparse (0.21+).
+    # This one originates inside sphinx_needs.layout.
+    # We'll drop these ignores once sphinx/sphinx_needs releases a fix.
+    ignore:^The frontend\.OptionParser class will be replaced by a subclass of argparse\.ArgumentParser in Docutils 0\.21 or later\.:DeprecationWarning:sphinx_needs\.layout
+
+    # This one bubbles up from stdlib optparse but is *explicitly* a Docutils message.
+    # We match the full message to avoid silencing unrelated optparse warnings.
+    # We'll drop these ignores once sphinx/sphinx_needs releases a fix.
+    ignore:^The frontend\.Option class will be removed in Docutils 0\.21 or later\.:DeprecationWarning:optparse


### PR DESCRIPTION
pytest logs are spammed with sphinx warnings.

This is kind of a workaround, as adding a custom pytest.ini to docs-as-code would require duplicating all the content, which would be a horrible idea. I don't know if we need some pytest.ini merge ability? But that would be crazy as well.