### PR TITLE
fix: failed tests do not show outputs

### DIFF
--- a/python_basics/score_pytest/py_pytest.bzl
+++ b/python_basics/score_pytest/py_pytest.bzl
@@ -36,7 +36,6 @@ def score_py_pytest(name, srcs, args = [], data = [], deps = [], env = {}, plugi
         args = [
                    "-c $(location %s)" % pytest_ini,
                    "-p no:cacheprovider",
-                   "--show-capture=no",
 
                    # XML_OUTPUT_FILE: Location to which test actions should write a test
                    # result XML output file. Otherwise, Bazel generates a default XML


### PR DESCRIPTION
Failed test cases should show information what happened. 

Currently all traces are not shown and once the failure happen we want to have as much information what was the problem as possible. Passed tests will still remain silent and won't show any output.