### PR TITLE
Make copyright_checker more flexible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 bazel-*
 MODULE.bazel.lock
+
+__pycache__

--- a/cr_checker/README.md
+++ b/cr_checker/README.md
@@ -1,6 +1,6 @@
 # CopyRight Checker
 
-`cr_checker.py` is a tool designed to check if files contain a specified copyright header. It provides configurable logging, color-coded console output, and can handle large file sets efficiently. The script supports reading configuration files for custom copyright templates and can utilize memory-mapped file reading for better performance with large files. Tool itself can also appened copyright header at the beggining of file if flag `--fix` is used.
+`cr_checker.py` is a tool designed to check if files contain a specified copyright header. It provides configurable logging, color-coded console output, and can handle large file sets efficiently. The script supports reading configuration files for custom copyright templates and can utilize memory-mapped file reading for better performance with large files. Tool itself can also append copyright header at the beginning of file if flag `--fix` is used.
 
 ## Features
 
@@ -10,7 +10,7 @@
 - Can use memory mapping for large file handling.
 - Customizable file encoding and offset adjustments for header text positioning.
 - Can append copyright headers.
-- Can remove provided number of characters from begining of the file.
+- Can remove provided number of characters from beginning of the file.
 
 ## Requirements
 
@@ -44,7 +44,7 @@ python cr_checker.py -t <template_file> [options] <inputs>
 
 > NOTE: Option `--remove-offset` can have severe consequences if the offset is miscalculated. Use with **extreme caution**.
 
-> NOTE: Setting directory as `.` will cause that tool removes your complete workspace! This is conected with how Bazel includes python into build. **DO NOT USE THIS OPTION UNLESS YOU'RE 100% SURE IN WHAT YOURE DOING**.
+> NOTE: Setting directory as `.` will cause that tool removes your complete workspace! This is connected with how Bazel includes python into build. **DO NOT USE THIS OPTION UNLESS YOU'RE 100% SURE IN WHAT YOU'RE DOING**.
 
 ### Examples
 
@@ -59,7 +59,7 @@ python cr_checker.py -t templates.ini -e py cpp --fix --offset 24 --use_memory_m
 
 #### A bit more about `--offset`
 
-This mode is special that will enable tool to do advance search & replace copyright headers. For example, asuming that we have following python implementation:
+This mode is special that will enable tool to do advance search & replace copyright headers. For example, assuming that we have following python implementation:
 
 ```python
 #!/usr/bin/env python3
@@ -97,21 +97,22 @@ if we apply this arguments now on same file, the outcome is different.
 import os
 ```
 
-On another hand, `--offset` has also another role. Asuming that a header text in file is soo big that copyright header is in the middle of the file, with regular command, the tool will not detect copyright headed. With `--offset=<NUM>` we can tell the tool from where to start considering the search for
+On another hand, `--offset` has also another role. Assuming that a header text in file is soo big that copyright header is in the middle of the file, with regular command, the tool will not detect copyright headed. With `--offset=<NUM>` we can tell the tool from where to start considering the search for
 copyright header.
 
 ### Template File Format
 
-The template file should be in INI format, with each section representing a file extension and a template key specifying the copyright text.
+The template file should be in INI format, with each section representing a file extension and a section specifying the copyright text.
+The copyright text can use format expressions to match the year and the author.
 
 Example templates.ini:
 
 ```ini
 [py,sh]
-template = # Copyright (c) 2024 Score Project
+# Copyright (c) {year} {author}
 
 [cpp,c,hpp, h]
-template = // Copyright (c) 2024 Score Project
+// Copyright (c) {year} {author}
 ```
 
 ## Exit Codes
@@ -166,7 +167,7 @@ copyright_checker(
 
 ### Integrate `cr_checker` using Bazel module
 
-The CopyRight check tool is integrated in other bazel repositroy using Bazel modules mechanism. The current tool is not registerd within BCR so private Bazel registry needs to be select. To select custom Bazel registery add following lines into .bazelrc:
+The CopyRight check tool is integrated in other bazel repository using Bazel modules mechanism. The current tool is not registered within BCR so private Bazel registry needs to be select. To select custom Bazel registry add following lines into .bazelrc:
 
 ```python
 common --registry=https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/

--- a/cr_checker/cr_checker.bzl
+++ b/cr_checker/cr_checker.bzl
@@ -44,7 +44,7 @@ def copyright_checker(
                                      Defaults to an empty list, meaning all files are checked.
         offset (int, optional): The line offset for applying checks or modifications.
                                 Defaults to 0.
-        remove_offset (int, optional): The line offset for removing chars from begining of file.
+        remove_offset (int, optional): The line offset for removing chars from beginning of file.
                                 Defaults to 0.
         debug (bool, optional): Whether to enable debug mode, providing additional logs.
                                 Defaults to False.

--- a/cr_checker/resources/config.json
+++ b/cr_checker/resources/config.json
@@ -1,3 +1,3 @@
 {
-    "years": [2024, 2025]
+    "author": "Contributors to the Eclipse Foundation"
 }

--- a/cr_checker/resources/templates.ini
+++ b/cr_checker/resources/templates.ini
@@ -12,7 +12,7 @@
 # *******************************************************************************
 [cpp,c,h,hpp]
 /********************************************************************************
- * Copyright (c) {year} Contributors to the Eclipse Foundation
+ * Copyright (c) {year} {author}
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -25,7 +25,7 @@
  ********************************************************************************/
 [py,sh,bzl,ini,yml,BUILD,bazel]
 # *******************************************************************************
-# Copyright (c) {year} Contributors to the Eclipse Foundation
+# Copyright (c) {year} {author}
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -39,7 +39,7 @@
 [rst]
 ..
    # *******************************************************************************
-   # Copyright (c) {year} Contributors to the Eclipse Foundation
+   # Copyright (c) {year} {author}
    #
    # See the NOTICE file(s) distributed with this work for additional
    # information regarding copyright ownership.

--- a/cr_checker/tests/test_shebang_handling.py
+++ b/cr_checker/tests/test_shebang_handling.py
@@ -41,9 +41,9 @@ def load_py_template() -> str:
 
 # write the config file here so that the year is always up to date with the year
 # written in the mock "script.py" file
-def write_config(path: Path, years: list[int]) -> Path:
+def write_config(path: Path, author: str) -> Path:
     config_path = path / "config.json"
-    config_path.write_text(json.dumps({"years": years}), encoding="utf-8")
+    config_path.write_text(json.dumps({"author": author}), encoding="utf-8")
     return config_path
 
 
@@ -67,18 +67,16 @@ def test_process_files_accepts_header_after_shebang(tmp_path):
     script = tmp_path / "script.py"
     header_template = load_py_template()
     current_year = datetime.now().year
-    header = header_template.format(year=current_year)
+    header = header_template.format(year=current_year, author="Author")
     script.write_text(
         "#!/usr/bin/env python3\n" + header + "print('hi')\n",
         encoding="utf-8",
     )
-    config = write_config(tmp_path, [current_year])
 
     results = cr_checker.process_files(
         [script],
         {"py": header_template},
         False,
-        config,
         use_mmap=False,
         encoding="utf-8",
         offset=0,
@@ -98,7 +96,8 @@ def test_process_files_fix_inserts_header_after_shebang(tmp_path):
     )
     header_template = load_py_template()
     current_year = datetime.now().year
-    config = write_config(tmp_path, [current_year])
+    author = "Author"
+    config = write_config(tmp_path, author)
 
     results = cr_checker.process_files(
         [script],
@@ -113,7 +112,7 @@ def test_process_files_fix_inserts_header_after_shebang(tmp_path):
 
     assert results["fixed"] == 1
     assert results["no_copyright"] == 1
-    expected_header = header_template.format(year=current_year)
+    expected_header = header_template.format(year=current_year, author=author)
     assert script.read_text(encoding="utf-8") == (
         "#!/usr/bin/env python3\n" + expected_header + "print('hi')\n"
     )
@@ -125,15 +124,13 @@ def test_process_files_accepts_header_without_shebang(tmp_path):
     script = tmp_path / "script.py"
     header_template = load_py_template()
     current_year = datetime.now().year
-    header = header_template.format(year=current_year)
+    header = header_template.format(year=current_year, author="Author")
     script.write_text(header + "print('hi')\n", encoding="utf-8")
-    config = write_config(tmp_path, [current_year])
 
     results = cr_checker.process_files(
         [script],
         {"py": header_template},
         False,
-        config,
         use_mmap=False,
         encoding="utf-8",
         offset=0,
@@ -150,7 +147,8 @@ def test_process_files_fix_inserts_header_without_shebang(tmp_path):
     script.write_text("print('hi')\n", encoding="utf-8")
     header_template = load_py_template()
     current_year = datetime.now().year
-    config = write_config(tmp_path, [current_year])
+    author = "Author"
+    config = write_config(tmp_path, author)
 
     results = cr_checker.process_files(
         [script],
@@ -165,5 +163,5 @@ def test_process_files_fix_inserts_header_without_shebang(tmp_path):
 
     assert results["fixed"] == 1
     assert results["no_copyright"] == 1
-    expected_header = header_template.format(year=current_year)
+    expected_header = header_template.format(year=current_year, author=author)
     assert script.read_text(encoding="utf-8") == expected_header + "print('hi')\n"


### PR DESCRIPTION
No need to configure a year, because that is now automatically matched. What you can configure now instead is the author (optional, default: Eclipse contributors).

Fixes #87