### PR TITLE
format: format Rust with VS Code

### DIFF
--- a/format_checker/README.md
+++ b/format_checker/README.md
@@ -86,6 +86,26 @@ This will register two Bazel targets:
 - `bazel run //:format.fix` — fixes format issues
 - `bazel test //:format.check` — fails on unformatted files
 
+### 3️⃣ In VS Code settings:
+
+⚠️ First formatting run can be slow!
+
+Add the following entry to `.vscode/settings.json`:
+
+```json
+"rust-analyzer.rustfmt.overrideCommand": [
+    "${workspaceFolder}/.vscode/rustfmt.sh"
+]
+```
+
+Add `.vscode/rustfmt.sh` file with `+x` permissions:
+
+```bash
+#!/usr/bin/env bash
+
+bazel run @score_tooling//format_checker:rustfmt_with_policies
+```
+
 ---
 
 ## Rust support

--- a/format_checker/tool/rustfmt_with_policies.sh
+++ b/format_checker/tool/rustfmt_with_policies.sh
@@ -11,7 +11,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
-set -euo pipefail
+
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+# shellcheck disable=SC1090
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
 
 RUSTFMT_BIN="$(rlocation rules_rust/tools/upstream_wrapper/rustfmt)"
 RUSTFMT_CONFIG="$(rlocation score_rust_policies/rustfmt/rustfmt.toml)"


### PR DESCRIPTION
- Add required preamble to run shell scripts from Bazel properly.
- Add docs on how to integrate IDE with Bazel target.