### PR TITLE
cr_checker: do not add enforce copyright headers for empty files

### DIFF
--- a/cr_checker/tool/cr_checker.py
+++ b/cr_checker/tool/cr_checker.py
@@ -528,6 +528,10 @@ def process_files(
             )
             continue
 
+        if os.path.getsize(item) == 0:
+            # No need to add copyright headers to empty files
+            continue
+
         # Automatically detect shebang and use its offset if no manual offset provided
         shebang_offset = detect_shebang_offset(item, encoding)
         effective_offset = offset + shebang_offset if offset == 0 else offset


### PR DESCRIPTION
With bazel it is quite common to have empty BUILD files for directories containing .bzl files, so we skip the copyright headers from those and all other empty files.