### PR TITLE
Add S-CORE requirements model in TRLC format

### DIFF
--- a/bazel/rules/rules_score/trlc/config/BUILD
+++ b/bazel/rules/rules_score/trlc/config/BUILD
@@ -1,0 +1,29 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@trlc//:trlc.bzl", "trlc_requirements_test", "trlc_specification")
+
+trlc_specification(
+    name = "score_requirements_model",
+    srcs = [
+        "score_requirements_model.rsl",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+trlc_requirements_test(
+    name = "score_requirements_model_test",
+    reqs = [
+        ":score_requirements_model",
+    ],
+)

--- a/bazel/rules/rules_score/trlc/config/README.rst
+++ b/bazel/rules/rules_score/trlc/config/README.rst
@@ -1,0 +1,64 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+S-CORE Requirements Metamodel
+==============================
+
+TRLC metamodel (``.rsl``) defining the requirement type hierarchy used throughout
+the repository.
+
+Type Hierarchy
+--------------
+
+::
+
+    Requirement (abstract)
+    ├── description: String
+    ├── version: Integer
+    ├── note: optional String
+    ├── status: Status {valid, invalid}
+    │
+    └── RequirementSafety (abstract, extends Requirement)
+        ├── safety: Asil {QM, B, D}
+        │
+        ├── AssumedSystemReq
+        │   └── rationale: String
+        │
+        ├── FeatReq
+        │   └── derived_from: list of ReqId
+        │
+        └── CompReq
+            └── derived_from: list of ReqId
+
+Usage
+-----
+
+Reference this metamodel as ``spec`` in ``trlc_requirements`` rules:
+
+.. code-block:: starlark
+
+    load("@trlc//:trlc.bzl", "trlc_requirements")
+
+    trlc_requirements(
+        name = "my_requirements",
+        srcs = ["requirements.trlc"],
+        spec = ["//tools/trlc/config:score_requirements_model"],
+    )
+
+Traceability
+------------
+
+``ReqId`` tuples (e.g., ``FeatReq.derived_from``) connect requirements across levels:
+``AssumedSystemReq`` → ``FeatReq`` → ``CompReq``, forming the traceability chain
+enforced by LOBSTER at the dependable-element level.

--- a/bazel/rules/rules_score/trlc/config/score_requirements_model.rsl
+++ b/bazel/rules/rules_score/trlc/config/score_requirements_model.rsl
@@ -1,0 +1,138 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+package ScoreReq
+
+enum Asil {
+    QM
+    B
+    D
+}
+
+enum Status {
+    valid
+    invalid
+}
+
+///////////////////////////////
+// Abstract Types
+///////////////////////////////
+
+abstract type Requirement {
+    description				String
+    version                 Integer
+	note optional           String
+    status                  Status
+    freeze status =         Status.valid
+}
+
+tuple ReqId {
+    item                     Requirement
+    separator                @
+    version                  Integer
+}
+
+abstract type RequirementSafety extends Requirement {
+    safety                  Asil
+}
+
+///////////////////////////////
+// S-Core Requirements Model
+///////////////////////////////
+
+type AssumedSystemReq extends RequirementSafety {
+    rationale				String
+}
+
+tuple AssumedSystemReqId {
+    item                     AssumedSystemReq
+    separator                @
+    version                  Integer
+}
+
+type FeatReq extends RequirementSafety {
+    derived_from			AssumedSystemReqId[1 .. *]
+}
+
+tuple FeatReqId {
+    item                     FeatReq
+    separator                @
+    version                  Integer
+}
+
+type CompReq extends RequirementSafety {
+    derived_from optional   FeatReqId[1 .. *]
+    fulfilledBy optional    String
+    mitigates optional      String
+}
+
+tuple CompReqId {
+    item                     CompReq
+    separator                @
+    version                  Integer
+}
+
+///////////////////////////////
+// Safety Analyses
+///////////////////////////////
+
+enum GuideWord {
+    TooEarly
+    TooLate
+    Wrong
+    LossOfFunction
+    PartialFunction
+    UnintendedFunction
+    ExceedingFunction
+    DelayedFunction
+}
+
+type FailureMode extends ScoreReq.RequirementSafety {
+    guideword               GuideWord
+    failureeffect           String
+    rationale optional      String
+    potentialcause optional String
+    interface optional      String
+}
+
+type ControlMeasure extends ScoreReq.RequirementSafety {
+    mitigates optional               String
+}
+
+type AoU extends ControlMeasure {
+}
+
+///////////////////////////////
+// Standards
+///////////////////////////////
+
+abstract type StdReq extends Requirement {
+}
+
+
+///////////////////////////////
+// Checks
+///////////////////////////////
+
+checks Requirement {
+
+    not matches(description, "(shall|should)"),
+        warning "The description must include (shall|should)",
+	    description
+
+}
+
+checks AssumedSystemReq {
+
+    rationale != null implies len(rationale) >= 5, "rationale too short"
+
+}


### PR DESCRIPTION
This allows TRLC to understand how requirements are structured in S-CORE.