### PR TITLE
fix(sphinx_wrapper): fix swapped stdout/stderr redirects and remove s…

### DIFF
--- a/bazel/rules/rules_score/src/sphinx_wrapper.py
+++ b/bazel/rules/rules_score/src/sphinx_wrapper.py
@@ -257,10 +257,9 @@ def main() -> int:
         stdout_processor = StdoutProcessor()
         stderr_processor = StderrProcessor()
         # Redirect stdout and stderr
-        with redirect_stderr(stdout_processor), redirect_stdout(stderr_processor):
+        with redirect_stderr(stderr_processor), redirect_stdout(stdout_processor):
             sphinx_args = build_sphinx_arguments(args)
             exit_code = run_sphinx_build(sphinx_args, args.builder)
-            exit_code = 0
         return exit_code
     except ValueError as e:
         logger.error(f"Validation error: {e}")


### PR DESCRIPTION
…hadowed exit code

redirect_stderr was incorrectly redirected to stdout_processor and redirect_stdout to stderr_processor. Also removes the unconditional exit_code = 0 assignment that was shadowing the actual return value from run_sphinx_build.