### PR TITLE
Ignore integration modules in main module

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,2 @@
+python_basics/integration_tests
+starpls/integration_tests


### PR DESCRIPTION
If not ignored a bazel test //... fails because submodule files are ignored.