### PR TITLE
Mark JVM depedency as dev dep

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -218,9 +218,9 @@ bazel_dep(name = "googletest", version = "1.17.0.bcr.2", dev_dependency = True)
 ###############################################################################
 # Blueprint Maven
 ###############################################################################
-bazel_dep(name = "rules_jvm_external", version = "6.10")
+bazel_dep(name = "rules_jvm_external", version = "6.10", dev_dependency = True)
 
-maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven", dev_dependency = True)
 maven.install(
     name = "blueprint_maven_dependencies",
     artifacts = [


### PR DESCRIPTION
In order to avoid that android_rules are being considered in depending projects like communication.