### PR TITLE
rules_score: Remove description from dependable_element

### DIFF
--- a/bazel/rules/rules_score/examples/seooc/BUILD
+++ b/bazel/rules/rules_score/examples/seooc/BUILD
@@ -55,7 +55,6 @@ dependable_element(
     dependability_analysis = [
         ":sample_dependability_analysis",
     ],
-    description = "Safety Element out of Context (SEooC) example",
     integrity_level = "B",
     requirements = [
         "//bazel/rules/rules_score/examples/seooc/docs/requirements:feature_requirements",

--- a/bazel/rules/rules_score/examples/some_other_library/BUILD
+++ b/bazel/rules/rules_score/examples/some_other_library/BUILD
@@ -51,7 +51,6 @@ dependable_element(
     assumptions_of_use = [],
     components = [":component_example"],
     dependability_analysis = [],
-    description = "XYZ",
     integrity_level = "D",
     requirements = [],
     tests = [],

--- a/bazel/rules/rules_score/private/dependable_element.bzl
+++ b/bazel/rules/rules_score/private/dependable_element.bzl
@@ -769,7 +769,6 @@ def _dependable_element_index_impl(ctx):
         substitutions = {
             "{title}": title,
             "{underline}": underline,
-            "{description}": ctx.attr.description,
             "{components}": components_ref,
             "{assumptions_of_use}": "\n   ".join(artifacts_by_type["assumptions_of_use"]),
             "{requirements}": "\n   ".join(artifacts_by_type["requirements"]),
@@ -988,10 +987,6 @@ _dependable_element_index = rule(
             mandatory = True,
             doc = "Name of the dependable element module (used as document title)",
         ),
-        "description": attr.string(
-            mandatory = True,
-            doc = "Description of the dependable element. Supports RST formatting.",
-        ),
         "assumptions_of_use": attr.label_list(
             mandatory = True,
             doc = "Assumptions of Use targets or files.",
@@ -1158,7 +1153,6 @@ _dependable_element_test = rule(
 # lobster-trace: Tools.ArchitectureModelingDependableElement
 def dependable_element(
         name,
-        description,
         assumptions_of_use,
         requirements,
         architectural_design,
@@ -1185,9 +1179,6 @@ def dependable_element(
     Args:
         name: The name of the dependable element. Used as the base name for
             all generated targets.
-        description: String containing a high-level description of the element.
-            This text provides context about what the element does and its purpose.
-            Supports RST formatting.
         assumptions_of_use: List of labels to assumptions_of_use targets that
             define the safety-relevant operating conditions and constraints.
         requirements: List of labels to requirements targets (component_requirements,
@@ -1227,7 +1218,6 @@ def dependable_element(
     _dependable_element_index(
         name = name + "_index",
         module_name = name,
-        description = description,
         template = Label("//bazel/rules/rules_score:templates/dependable_element_index.template.rst"),
         assumptions_of_use = assumptions_of_use,
         requirements = requirements,

--- a/bazel/rules/rules_score/templates/dependable_element_index.template.rst
+++ b/bazel/rules/rules_score/templates/dependable_element_index.template.rst
@@ -15,8 +15,6 @@
 Dependable element: {title}
 ===================={underline}
 
-{description}
-
 Architectural Design
 --------------------
 

--- a/bazel/rules/rules_score/test/BUILD
+++ b/bazel/rules/rules_score/test/BUILD
@@ -69,7 +69,6 @@ load(
 load(
     ":seooc_test.bzl",
     "seooc_artifacts_copied_test",
-    "seooc_description_test",
     "seooc_index_generation_test",
     "seooc_needs_provider_test",
     "seooc_sphinx_module_generated_test",
@@ -214,7 +213,6 @@ dependable_element(
     assumptions_of_use = [":aous"],
     components = [],
     dependability_analysis = [":dependability_analysis_target"],
-    description = "Dependency SEooC module for testing the deps attribute of dependable_element.",
     integrity_level = "B",
     requirements = [":feat_req"],
     tests = [],
@@ -227,7 +225,6 @@ dependable_element(
     assumptions_of_use = [":aous"],
     components = [],
     dependability_analysis = [":dependability_analysis_target"],
-    description = "Test SEooC module demonstrating S-CORE process compliance structure.",
     integrity_level = "B",
     requirements = [":feat_req"],
     tests = [],
@@ -336,7 +333,6 @@ dependable_element(
     assumptions_of_use = [":aous"],
     components = [":test_component"],
     dependability_analysis = [":dependability_analysis_target"],
-    description = "Test dependable element for unit testing",
     integrity_level = "B",
     requirements = [":feat_req"],
     tests = [],  # Empty for testing
@@ -408,7 +404,6 @@ dependable_element(
     assumptions_of_use = [":aous"],
     components = [":test_parent_component"],
     dependability_analysis = [":dependability_analysis_target"],
-    description = "Test dependable element with nested components for testing recursive unit collection and deduplication",
     integrity_level = "B",
     requirements = [":feat_req"],
     tests = [],
@@ -501,11 +496,6 @@ seooc_index_generation_test(
     target_under_test = ":seooc_test_lib_index",
 )
 
-seooc_description_test(
-    name = "seooc_tests_description",
-    target_under_test = ":seooc_test_lib_index",
-)
-
 # ============================================================================
 # Test Suites
 # ============================================================================
@@ -571,7 +561,6 @@ test_suite(
     name = "seooc_tests",
     tests = [
         ":seooc_tests_artifacts_copied",
-        ":seooc_tests_description",
         ":seooc_tests_index_generation",
         ":seooc_tests_needs_provider",
         ":seooc_tests_sphinx_module_generated",

--- a/bazel/rules/rules_score/test/seooc_test.bzl
+++ b/bazel/rules/rules_score/test/seooc_test.bzl
@@ -115,33 +115,3 @@ def _seooc_needs_provider_test_impl(ctx):
 seooc_needs_provider_test = analysistest.make(
     impl = _seooc_needs_provider_test_impl,
 )
-
-def _seooc_description_test_impl(ctx):
-    """Test that SEooC includes description in generated index.rst."""
-    env = analysistest.begin(ctx)
-    target_under_test = analysistest.target_under_test(env)
-
-    # Get the generated index file
-    files = target_under_test[DefaultInfo].files.to_list()
-
-    # Find index.rst
-    index_file = None
-    for f in files:
-        if f.basename == "index.rst":
-            index_file = f
-            break
-
-    # Note: We can't easily read file contents in analysis test,
-    # but we can verify the file exists. The description content
-    # would be validated through integration tests or manual inspection.
-    asserts.true(
-        env,
-        index_file != None,
-        "Expected index.rst to exist for description validation",
-    )
-
-    return analysistest.end(env)
-
-seooc_description_test = analysistest.make(
-    impl = _seooc_description_test_impl,
-)


### PR DESCRIPTION
We do not want that in BUILD files, we have to write descriptions. This seems unnatural, what the dependable element does, comes out of the whole architecture / design description.