### PR TITLE
rules_score: Forward standard args

### DIFF
--- a/bazel/rules/rules_score/private/architectural_design.bzl
+++ b/bazel/rules/rules_score/private/architectural_design.bzl
@@ -237,7 +237,7 @@ def architectural_design(
         static = [],
         dynamic = [],
         public_api = [],
-        visibility = None):
+        **kwargs):
     """Define architectural design following S-CORE process guidelines.
 
     Architectural design documents describe the software architecture of a
@@ -288,5 +288,5 @@ def architectural_design(
         static = static,
         dynamic = dynamic,
         public_api = public_api,
-        visibility = visibility,
+        **kwargs
     )

--- a/bazel/rules/rules_score/private/assumed_system_requirements.bzl
+++ b/bazel/rules/rules_score/private/assumed_system_requirements.bzl
@@ -32,7 +32,7 @@ def assumed_system_requirements(
         deps = [],
         spec = Label("//bazel/rules/rules_score/trlc/config:score_requirements_model"),
         ref_package = "",
-        visibility = None):
+        **kwargs):
     """Define Assumed System Requirements following S-CORE process guidelines.
 
     Creates a target providing AssumedSystemRequirementsInfo, TrlcProviderInfo,
@@ -82,10 +82,10 @@ def assumed_system_requirements(
         lobster_config = Label("//bazel/rules/rules_score/lobster/config:assumed_system_requirement"),
         spec = spec,
         ref_package = ref_package,
-        visibility = visibility,
+        **kwargs
     )
     trlc_requirements_test(
         name = name + "_test",
         reqs = [":" + name],
-        visibility = visibility,
+        **kwargs
     )

--- a/bazel/rules/rules_score/private/assumptions_of_use.bzl
+++ b/bazel/rules/rules_score/private/assumptions_of_use.bzl
@@ -129,7 +129,7 @@ def assumptions_of_use(
         srcs,
         requirements = [],
         ref_package = None,
-        visibility = None):
+        **kwargs):
     """Define Assumptions of Use following S-CORE process guidelines.
 
     Assumptions of Use (AoU) define the safety-relevant operating conditions
@@ -179,10 +179,10 @@ def assumptions_of_use(
         name = name,
         srcs = trlc_srcs,
         requirements = requirements,
-        visibility = visibility,
+        **kwargs
     )
     trlc_requirements_test(
         name = name + "_test",
         reqs = trlc_srcs,
-        visibility = visibility,
+        **kwargs
     )

--- a/bazel/rules/rules_score/private/component.bzl
+++ b/bazel/rules/rules_score/private/component.bzl
@@ -263,8 +263,7 @@ def component(
         requirements = None,
         components = [],
         testonly = True,
-        visibility = None,
-        tags = []):
+        **kwargs):
     """Define a software component following S-CORE process guidelines.
 
     A component is a collection of related units that together provide
@@ -302,6 +301,5 @@ def component(
         components = components,
         tests = tests,
         testonly = testonly,
-        visibility = visibility,
-        tags = tags,
+        **kwargs
     )

--- a/bazel/rules/rules_score/private/component_requirements.bzl
+++ b/bazel/rules/rules_score/private/component_requirements.bzl
@@ -31,7 +31,7 @@ def component_requirements(
         deps = [],
         spec = Label("//bazel/rules/rules_score/trlc/config:score_requirements_model"),
         ref_package = "",
-        visibility = None):
+        **kwargs):
     """Define component requirements following S-CORE process guidelines.
 
     Creates a target providing ComponentRequirementsInfo, TrlcProviderInfo,
@@ -76,10 +76,10 @@ def component_requirements(
         lobster_config = Label("//bazel/rules/rules_score/lobster/config:component_requirement"),
         spec = spec,
         ref_package = ref_package,
-        visibility = visibility,
+        **kwargs
     )
     trlc_requirements_test(
         name = name + "_test",
         reqs = [":" + name],
-        visibility = visibility,
+        **kwargs
     )

--- a/bazel/rules/rules_score/private/dependability_analysis.bzl
+++ b/bazel/rules/rules_score/private/dependability_analysis.bzl
@@ -244,8 +244,7 @@ def dependability_analysis(
         security_analysis = [],
         dfa = [],
         arch_design = None,
-        visibility = None,
-        tags = []):
+        **kwargs):
     """Define dependability analysis following S-CORE process guidelines.
 
     Aggregates up to three sub-analysis rules and validates the combined
@@ -281,6 +280,5 @@ def dependability_analysis(
         security_analysis = security_analysis,
         dfa = dfa,
         arch_design = arch_design,
-        visibility = visibility,
-        tags = tags,
+        **kwargs
     )

--- a/bazel/rules/rules_score/private/feature_requirements.bzl
+++ b/bazel/rules/rules_score/private/feature_requirements.bzl
@@ -32,7 +32,7 @@ def feature_requirements(
         deps = [],
         spec = Label("//bazel/rules/rules_score/trlc/config:score_requirements_model"),
         ref_package = "",
-        visibility = None):
+        **kwargs):
     """Define feature requirements following S-CORE process guidelines.
 
     Creates a target providing FeatureRequirementsInfo, TrlcProviderInfo,
@@ -82,10 +82,10 @@ def feature_requirements(
         lobster_config = Label("//bazel/rules/rules_score/lobster/config:feature_requirement"),
         spec = spec,
         ref_package = ref_package,
-        visibility = visibility,
+        **kwargs
     )
     trlc_requirements_test(
         name = name + "_test",
         reqs = [":" + name],
-        visibility = visibility,
+        **kwargs
     )

--- a/bazel/rules/rules_score/private/fmea.bzl
+++ b/bazel/rules/rules_score/private/fmea.bzl
@@ -411,8 +411,7 @@ def fmea(
         controlmeasures = [],
         root_causes = [],
         arch_design = None,
-        visibility = None,
-        tags = []):
+        **kwargs):
     """Define FMEA (Failure Mode and Effects Analysis) following S-CORE process guidelines.
 
     Generates a single ``fmea.rst`` page with up to three sections:
@@ -443,6 +442,5 @@ def fmea(
         controlmeasures = controlmeasures,
         root_causes = root_causes,
         arch_design = arch_design,
-        visibility = visibility,
-        tags = tags,
+        **kwargs
     )

--- a/bazel/rules/rules_score/private/requirements.bzl
+++ b/bazel/rules/rules_score/private/requirements.bzl
@@ -182,7 +182,7 @@ def score_requirements_rule(
         deps = [],
         spec = Label("//bazel/rules/rules_score/trlc/config:score_requirements_model"),
         ref_package = "",
-        visibility = None):
+        **kwargs):
     """Macro wrapper around _score_requirements_rule with RST support.
 
     Any .rst files in srcs are converted to .trlc via rst_to_trlc before
@@ -214,5 +214,5 @@ def score_requirements_rule(
         req_kind = req_kind,
         lobster_config = lobster_config,
         spec = spec,
-        visibility = visibility,
+        **kwargs
     )

--- a/bazel/rules/rules_score/private/unit.bzl
+++ b/bazel/rules/rules_score/private/unit.bzl
@@ -143,7 +143,7 @@ def unit(
         tests,
         scope = [],
         testonly = True,
-        visibility = None):
+        **kwargs):
     """Define a software unit following S-CORE process guidelines.
 
     A unit is the smallest testable software element in the S-CORE process.
@@ -188,5 +188,5 @@ def unit(
         scope = scope,
         tests = tests,
         testonly = testonly,
-        visibility = visibility,
+        **kwargs
     )

--- a/bazel/rules/rules_score/private/unit_design.bzl
+++ b/bazel/rules/rules_score/private/unit_design.bzl
@@ -138,7 +138,7 @@ def unit_design(
         name,
         static = [],
         dynamic = [],
-        visibility = None):
+        **kwargs):
     """Define unit design following S-CORE process guidelines.
 
     Unit design documents describe the internal design of a software unit,
@@ -192,5 +192,5 @@ def unit_design(
         name = name,
         static = static,
         dynamic = dynamic,
-        visibility = visibility,
+        **kwargs
     )


### PR DESCRIPTION
Its a best practice to forward all bazel standard args in marcos via the kwargs attribute. This avoids code duplication for implicit attributes.