### PR TITLE
rules_score: sphinx_module for html should not forward needs

### DIFF
--- a/bazel/rules/rules_score/private/sphinx_module.bzl
+++ b/bazel/rules/rules_score/private/sphinx_module.bzl
@@ -266,7 +266,7 @@ def _score_html_impl(ctx):
         tools = [sphinx_toolchain.html_merge_tool.files_to_run],
     )
     return [
-        DefaultInfo(files = depset(ctx.files.needs + [html_output])),
+        DefaultInfo(files = depset([html_output])),
         SphinxModuleInfo(
             html_dir = html_output,
         ),


### PR DESCRIPTION
The needs get forwarded by the custom needs rule, no need that the HTML does the very same.