### PR TITLE
[rules score] use Markup_String for requirement description field

### DIFF
--- a/bazel/rules/rules_score/trlc/config/score_requirements_model.rsl
+++ b/bazel/rules/rules_score/trlc/config/score_requirements_model.rsl
@@ -29,7 +29,7 @@ enum Status {
 
 abstract type Requirement "Base type for all S-CORE requirements." {
     description "The normative requirement text. Must express an obligation (shall/should)."
-                String
+                Markup_String
     version     "Monotonically increasing version counter. Increment on every content change."
                 Integer
     note        "Non-normative explanatory text providing additional context."


### PR DESCRIPTION
Update `score_requirements_model.rsl` to change the `description` field type from `String` to `Markup_String`, enabling [[references]] in requirement descriptions to be rendered as Sphinx cross-refs.

Required by: https://github.com/bmw-software-engineering/trlc/pull/192