### PR TITLE
feat: include combined coverage HTML in docs build and CI

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y pkg-config libcairo2-dev
+          sudo apt-get install -y pkg-config libcairo2-dev lcov
       - name: Determine version
         id: version
         run: |
@@ -63,6 +63,8 @@ jobs:
           fi
       - name: Build Sphinx documentation
         run: bazel build //bazel/rules/rules_score:rules_score_doc
+      - name: Generate combined coverage report
+        run: bazel run //coverage:combined_report -- --out-dir coverage-html
       - name: Prepare documentation output
         run: |
           BAZEL_BIN="$(bazel info bazel-bin)"
@@ -76,6 +78,12 @@ jobs:
           mkdir -p docs_output
           cp -r "${HTML_DIR}/." docs_output/
           chmod -R u+w docs_output/
+
+          # Embed the combined coverage report at docs_output/coverage/
+          if [[ -d coverage-html ]]; then
+            mkdir -p docs_output/coverage
+            cp -r coverage-html/. docs_output/coverage/
+          fi
 
           # Prevent Jekyll from ignoring _static directories
           touch docs_output/.nojekyll

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -120,6 +120,7 @@ jobs:
           path: coverage-html/
       - name: Post coverage summary to PR
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -20,12 +20,14 @@ on:
     branches: [main]
     paths:
       - 'bazel/rules/rules_score/docs/**'
+      - 'coverage/**'
       - '.github/workflows/deploy_docs.yml'
   workflow_dispatch:
 permissions:
   contents: write # needed for uploading release assets
   pages: write
   id-token: write
+  pull-requests: write # needed for posting PR comments
 concurrency:
   group: "pages"
   cancel-in-progress: false
@@ -64,7 +66,14 @@ jobs:
       - name: Build Sphinx documentation
         run: bazel build //bazel/rules/rules_score:rules_score_doc
       - name: Generate combined coverage report
-        run: bazel run //coverage:combined_report -- --out-dir coverage-html
+        id: coverage
+        run: |
+          COVERAGE_OUTPUT=$(bazel run //coverage:combined_report -- --out-dir coverage-html 2>&1)
+          echo "${COVERAGE_OUTPUT}"
+          LINES=$(echo "${COVERAGE_OUTPUT}" | grep -oP 'lines\.+: \K[\d.]+%' | head -1 | tr -d '\n' || echo 'N/A')
+          FUNCTIONS=$(echo "${COVERAGE_OUTPUT}" | grep -oP 'functions\.+: \K[\d.]+%' | head -1 | tr -d '\n' || echo 'N/A')
+          echo "lines=${LINES}" >> "$GITHUB_OUTPUT"
+          echo "functions=${FUNCTIONS}" >> "$GITHUB_OUTPUT"
       - name: Prepare documentation output
         run: |
           BAZEL_BIN="$(bazel info bazel-bin)"
@@ -102,6 +111,40 @@ jobs:
           fi
           echo "Documentation built successfully"
           find docs_output -type f | wc -l | xargs -I{} echo "Total files: {}"
+      - name: Upload coverage report artifact
+        if: always()
+        id: upload-coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage-html/
+      - name: Post coverage summary to PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const lines = '${{ steps.coverage.outputs.lines }}';
+            const functions = '${{ steps.coverage.outputs.functions }}';
+            const runUrl = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
+            const body = [
+              '## Coverage Report',
+              '',
+              'Coverage report was generated.',
+              '',
+              `**Full report** can be downloaded from the [CI artifacts](${runUrl}) (expand **Artifacts** at the bottom of the run).`,
+              '',
+              '**Overall coverage rate:**',
+              '```',
+              `lines......: ${lines}`,
+              `functions......: ${functions}`,
+              '```'
+            ].join('\n');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });
       - name: Upload docs to release
         if: startsWith(github.ref, 'refs/tags/v')
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,3 +57,25 @@ jobs:
       - name: Ensure correct dependency resolution
         run: |
           bazel mod deps --lockfile_mode=update
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+      - name: Setup Bazel with cache
+        uses: bazel-contrib/setup-bazel@0.19.0
+        with:
+          disk-cache: true
+          repository-cache: true
+          bazelisk-cache: true
+      - name: Install lcov
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y lcov
+      - name: Generate combined coverage report
+        run: bazel run //coverage:combined_report -- --out-dir coverage-html
+      - name: Upload coverage report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage-html/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,25 +57,3 @@ jobs:
       - name: Ensure correct dependency resolution
         run: |
           bazel mod deps --lockfile_mode=update
-  coverage:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6.0.2
-      - name: Setup Bazel with cache
-        uses: bazel-contrib/setup-bazel@0.19.0
-        with:
-          disk-cache: true
-          repository-cache: true
-          bazelisk-cache: true
-      - name: Install lcov
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y lcov
-      - name: Generate combined coverage report
-        run: bazel run //coverage:combined_report -- --out-dir coverage-html
-      - name: Upload coverage report artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-report
-          path: coverage-html/

--- a/bazel/rules/rules_score/docs/quality_report.rst
+++ b/bazel/rules/rules_score/docs/quality_report.rst
@@ -12,19 +12,18 @@
    # SPDX-License-Identifier: Apache-2.0
    # *******************************************************************************
 
-SCORE Rules for Bazel
-=====================
+Quality Report
+==============
 
-``rules_score`` provides Bazel build rules for structuring and documenting
-safety-critical software according to S-CORE process guidelines. It covers
-the full artefact lifecycle — from requirements and architecture through
-safety analysis to the top-level SEooC assembly.
+This section provides quality reports generated for the tooling repository.
 
-.. toctree::
-   :maxdepth: 2
+Code Coverage
+-------------
 
-   overview
-   integration_guide
-   user_guide/index
-   rule_reference
-   quality_report
+The combined Rust + Python HTML coverage report is generated using:
+
+.. code-block:: bash
+
+   bazel run //coverage:combined_report
+
+`View Coverage Report <coverage/index.html>`_


### PR DESCRIPTION
 include combined coverage HTML in docs build and CI

Integrates the combined Rust + Python HTML coverage report into both the docs build and CI pipeline. The report is embedded at [coverage](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and linked from a new Quality Report page in the documentation sidebar. A dedicated [coverage](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) CI job is also added to [tests.yml](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) that generates and uploads the report as a downloadable artifact.