### PR TITLE
fix(rules_score): allow lobster config override in requirement macros

### DIFF
--- a/bazel/rules/rules_score/private/assumed_system_requirements.bzl
+++ b/bazel/rules/rules_score/private/assumed_system_requirements.bzl
@@ -31,6 +31,7 @@ def assumed_system_requirements(
         srcs,
         deps = [],
         spec = Label("//bazel/rules/rules_score/trlc/config:score_requirements_model"),
+        lobster_config = Label("//bazel/rules/rules_score/lobster/config:assumed_system_requirement"),
         ref_package = "",
         **kwargs):
     """Define Assumed System Requirements following S-CORE process guidelines.
@@ -53,6 +54,8 @@ def assumed_system_requirements(
             Defaults to the S-CORE requirements model
             (``@score_tooling//bazel/rules/rules_score/trlc/config:score_requirements_model``).
             Override this when using a custom requirements model.
+        lobster_config: Optional Lobster extraction config label. Defaults to the
+            S-CORE assumed system requirement config.
         visibility: Bazel visibility specification for the generated targets.
 
     Generated Targets:
@@ -79,7 +82,7 @@ def assumed_system_requirements(
         srcs = srcs,
         deps = deps,
         req_kind = "assumed_system",
-        lobster_config = Label("//bazel/rules/rules_score/lobster/config:assumed_system_requirement"),
+        lobster_config = lobster_config,
         spec = spec,
         ref_package = ref_package,
         **kwargs

--- a/bazel/rules/rules_score/private/component_requirements.bzl
+++ b/bazel/rules/rules_score/private/component_requirements.bzl
@@ -30,6 +30,7 @@ def component_requirements(
         srcs,
         deps = [],
         spec = Label("//bazel/rules/rules_score/trlc/config:score_requirements_model"),
+        lobster_config = Label("//bazel/rules/rules_score/lobster/config:component_requirement"),
         ref_package = "",
         **kwargs):
     """Define component requirements following S-CORE process guidelines.
@@ -52,6 +53,8 @@ def component_requirements(
             Defaults to the S-CORE requirements model
             (``@score_tooling//bazel/rules/rules_score/trlc/config:score_requirements_model``).
             Override this when using a custom requirements model.
+        lobster_config: Optional Lobster extraction config label. Defaults to the
+            S-CORE component requirement config.
         visibility: Bazel visibility specification for the generated targets.
 
     Generated Targets:
@@ -73,7 +76,7 @@ def component_requirements(
         srcs = srcs,
         deps = deps,
         req_kind = "component",
-        lobster_config = Label("//bazel/rules/rules_score/lobster/config:component_requirement"),
+        lobster_config = lobster_config,
         spec = spec,
         ref_package = ref_package,
         **kwargs

--- a/bazel/rules/rules_score/private/feature_requirements.bzl
+++ b/bazel/rules/rules_score/private/feature_requirements.bzl
@@ -31,6 +31,7 @@ def feature_requirements(
         srcs,
         deps = [],
         spec = Label("//bazel/rules/rules_score/trlc/config:score_requirements_model"),
+        lobster_config = Label("//bazel/rules/rules_score/lobster/config:feature_requirement"),
         ref_package = "",
         **kwargs):
     """Define feature requirements following S-CORE process guidelines.
@@ -53,6 +54,8 @@ def feature_requirements(
             Defaults to the S-CORE requirements model
             (``@score_tooling//bazel/rules/rules_score/trlc/config:score_requirements_model``).
             Override this when using a custom requirements model.
+        lobster_config: Optional Lobster extraction config label. Defaults to the
+            S-CORE feature requirement config.
         visibility: Bazel visibility specification for the generated targets.
 
     Generated Targets:
@@ -79,7 +82,7 @@ def feature_requirements(
         srcs = srcs,
         deps = deps,
         req_kind = "feature",
-        lobster_config = Label("//bazel/rules/rules_score/lobster/config:feature_requirement"),
+        lobster_config = lobster_config,
         spec = spec,
         ref_package = ref_package,
         **kwargs


### PR DESCRIPTION
Why: repositories using extended requirement metamodels cannot use the default ScoreReq lobster extraction config without patching.
What: add optional lobster_config parameters to feature, component, and assumed-system requirement macros and pass them through to score_requirements_rule while keeping existing defaults unchanged.