### PR TITLE
Fix image asset staging for SCORE requirements rules

### DIFF
--- a/bazel/rules/rules_score/private/assumed_system_requirements.bzl
+++ b/bazel/rules/rules_score/private/assumed_system_requirements.bzl
@@ -32,6 +32,7 @@ def assumed_system_requirements(
         deps = [],
         spec = Label("//bazel/rules/rules_score/trlc/config:score_requirements_model"),
         ref_package = "",
+        image_srcs = [],
         **kwargs):
     """Define Assumed System Requirements following S-CORE process guidelines.
 
@@ -82,6 +83,7 @@ def assumed_system_requirements(
         lobster_config = Label("//bazel/rules/rules_score/lobster/config:assumed_system_requirement"),
         spec = spec,
         ref_package = ref_package,
+        image_srcs = image_srcs,
         **kwargs
     )
     trlc_requirements_test(

--- a/bazel/rules/rules_score/private/component_requirements.bzl
+++ b/bazel/rules/rules_score/private/component_requirements.bzl
@@ -31,6 +31,7 @@ def component_requirements(
         deps = [],
         spec = Label("//bazel/rules/rules_score/trlc/config:score_requirements_model"),
         ref_package = "",
+        image_srcs = [],
         **kwargs):
     """Define component requirements following S-CORE process guidelines.
 
@@ -76,6 +77,7 @@ def component_requirements(
         lobster_config = Label("//bazel/rules/rules_score/lobster/config:component_requirement"),
         spec = spec,
         ref_package = ref_package,
+        image_srcs = image_srcs,
         **kwargs
     )
     trlc_requirements_test(

--- a/bazel/rules/rules_score/private/feature_requirements.bzl
+++ b/bazel/rules/rules_score/private/feature_requirements.bzl
@@ -32,6 +32,7 @@ def feature_requirements(
         deps = [],
         spec = Label("//bazel/rules/rules_score/trlc/config:score_requirements_model"),
         ref_package = "",
+        image_srcs = [],
         **kwargs):
     """Define feature requirements following S-CORE process guidelines.
 
@@ -82,6 +83,7 @@ def feature_requirements(
         lobster_config = Label("//bazel/rules/rules_score/lobster/config:feature_requirement"),
         spec = spec,
         ref_package = ref_package,
+        image_srcs = image_srcs,
         **kwargs
     )
     trlc_requirements_test(

--- a/bazel/rules/rules_score/private/requirements.bzl
+++ b/bazel/rules/rules_score/private/requirements.bzl
@@ -105,7 +105,26 @@ def _requirements_impl(ctx):
             name = ctx.label.name,
         )
 
-    sphinx_srcs = depset([rendered_file])
+    image_outputs = []
+    package_prefix = ctx.label.package + "/"
+    for image in ctx.files.image_srcs:
+        relative_path = image.short_path
+
+        # Keep `.. image:: img/...` references stable across packages.
+        # If the source path contains an img segment, stage from there.
+        img_split = relative_path.split("/img/", 1)
+        if len(img_split) == 2:
+            relative_path = "img/" + img_split[1]
+        elif relative_path.startswith(package_prefix):
+            relative_path = relative_path[len(package_prefix):]
+        else:
+            relative_path = image.basename
+
+        output = ctx.actions.declare_file(relative_path)
+        ctx.actions.symlink(output = output, target_file = image)
+        image_outputs.append(output)
+
+    sphinx_srcs = depset([rendered_file] + image_outputs)
 
     transitive_sphinx = [sphinx_srcs]
     for dep in ctx.attr.deps:
@@ -163,6 +182,11 @@ _score_requirements_rule = rule(
             default = Label("//bazel/rules/rules_score/trlc/config:score_requirements_model"),
             doc = "TRLC specification target providing the RSL files that define the requirement types. Defaults to the S-CORE requirements model.",
         ),
+        "image_srcs": attr.label_list(
+            allow_files = True,
+            default = [],
+            doc = "Image files to stage relative to the rendered requirements RST.",
+        ),
         "_renderer": attr.label(
             default = Label("@trlc//tools/trlc_rst:trlc_rst"),
             executable = True,
@@ -181,6 +205,7 @@ def score_requirements_rule(
         deps = [],
         spec = Label("//bazel/rules/rules_score/trlc/config:score_requirements_model"),
         ref_package = "",
+        image_srcs = [],
         **kwargs):
     """Macro wrapper around _score_requirements_rule with RST support.
 
@@ -213,5 +238,6 @@ def score_requirements_rule(
         req_kind = req_kind,
         lobster_config = lobster_config,
         spec = spec,
+        image_srcs = image_srcs,
         **kwargs
     )


### PR DESCRIPTION
**Summary**
This PR fixes image staging for SCORE requirements documentation so image references inside rendered requirement pages are resolved correctly during HTML generation.

**What changed**
Added an optional image_srcs attribute to:
  1. assumed_system_requirements
  2. feature_requirements
  3. component_requirements
  4. score_requirements_rule
Wired image_srcs through to the internal _score_requirements_rule.