### PR TITLE
Class MetaModel Consistency Between PUML and C++

### DIFF
--- a/plantuml/parser/integration_test/class_diagram/class_diagram_enum_value_sequence/class_diagram_enum_value_sequence.puml
+++ b/plantuml/parser/integration_test/class_diagram/class_diagram_enum_value_sequence/class_diagram_enum_value_sequence.puml
@@ -1,0 +1,48 @@
+' *******************************************************************************
+' Copyright (c) 2026 Contributors to the Eclipse Foundation
+'
+' See the NOTICE file(s) distributed with this work for additional
+' information regarding copyright ownership.
+'
+' This program and the accompanying materials are made available under the
+' terms of the Apache License Version 2.0 which is available at
+' https://www.apache.org/licenses/LICENSE-2.0
+'
+' SPDX-License-Identifier: Apache-2.0
+' *******************************************************************************
+@startuml class_diagram_enum_value_sequence
+
+namespace util {
+    ' the sentinal value is positive
+    enum LogLevel {
+        De = 5
+        Info
+        Warn : Warnning
+        Err
+        Fatal = 10
+        Trace
+    }
+}
+
+namespace system {
+    ' the sentinal value is not set
+    enum SystemState {
+        Init
+        Running : Active
+        Stopped = 10
+        Failed
+    }
+}
+
+namespace platform {
+    ' the sentinal value is nagtive
+    enum PowerMode {
+        Unknown = -5
+        Off
+        Standby = 0
+        Active : Running
+        Sleep
+    }
+}
+
+@enduml

--- a/plantuml/parser/integration_test/class_diagram/class_diagram_enum_value_sequence/output.json
+++ b/plantuml/parser/integration_test/class_diagram/class_diagram_enum_value_sequence/output.json
@@ -1,0 +1,117 @@
+{
+  "class_diagram_enum_value_sequence.puml": {
+    "name": "class_diagram_enum_value_sequence",
+    "entities": [
+      {
+        "id": "util.LogLevel",
+        "name": "LogLevel",
+        "enclosing_namespace_id": "util",
+        "entity_type": "Enum",
+        "type_aliases": [],
+        "methods": [],
+        "template_parameters": null,
+        "enum_literals": [
+          {
+            "name": "De",
+            "value": 5
+          },
+          {
+            "name": "Info",
+            "value": 6
+          },
+          {
+            "name": "Warn",
+            "value": 7
+          },
+          {
+            "name": "Err",
+            "value": 8
+          },
+          {
+            "name": "Fatal",
+            "value": 10
+          },
+          {
+            "name": "Trace",
+            "value": 11
+          }
+        ],
+        "source_file": "class_diagram_enum_value_sequence",
+        "source_line": 17,
+        "variables": [],
+        "relationships": []
+      },
+      {
+        "id": "system.SystemState",
+        "name": "SystemState",
+        "enclosing_namespace_id": "system",
+        "entity_type": "Enum",
+        "type_aliases": [],
+        "methods": [],
+        "template_parameters": null,
+        "enum_literals": [
+          {
+            "name": "Init",
+            "value": 0
+          },
+          {
+            "name": "Running",
+            "value": 1
+          },
+          {
+            "name": "Stopped",
+            "value": 10
+          },
+          {
+            "name": "Failed",
+            "value": 11
+          }
+        ],
+        "source_file": "class_diagram_enum_value_sequence",
+        "source_line": 29,
+        "variables": [],
+        "relationships": []
+      },
+      {
+        "id": "platform.PowerMode",
+        "name": "PowerMode",
+        "enclosing_namespace_id": "platform",
+        "entity_type": "Enum",
+        "type_aliases": [],
+        "methods": [],
+        "template_parameters": null,
+        "enum_literals": [
+          {
+            "name": "Unknown",
+            "value": -5
+          },
+          {
+            "name": "Off",
+            "value": -4
+          },
+          {
+            "name": "Standby",
+            "value": 0
+          },
+          {
+            "name": "Active",
+            "value": 1
+          },
+          {
+            "name": "Sleep",
+            "value": 2
+          }
+        ],
+        "source_file": "class_diagram_enum_value_sequence",
+        "source_line": 39,
+        "variables": [],
+        "relationships": []
+      }
+    ],
+    "relationships": [],
+    "source_files": [
+      "class_diagram_enum_value_sequence"
+    ],
+    "version": null
+  }
+}

--- a/plantuml/parser/integration_test/class_diagram/class_diagram_positive/output.json
+++ b/plantuml/parser/integration_test/class_diagram/class_diagram_positive/output.json
@@ -18,15 +18,13 @@
             "name": "x",
             "data_type": "f32",
             "visibility": "public",
-            "is_static": false,
-            "is_const": false
+            "is_static": false
           },
           {
             "name": "y",
             "data_type": "f32",
             "visibility": "public",
-            "is_static": false,
-            "is_const": false
+            "is_static": false
           }
         ],
         "relationships": []
@@ -47,15 +45,13 @@
             "name": "width",
             "data_type": "f32",
             "visibility": "public",
-            "is_static": false,
-            "is_const": false
+            "is_static": false
           },
           {
             "name": "height",
             "data_type": "f32",
             "visibility": "public",
-            "is_static": false,
-            "is_const": false
+            "is_static": false
           }
         ],
         "relationships": []
@@ -71,15 +67,15 @@
         "enum_literals": [
           {
             "name": "Red",
-            "value": "0"
+            "value": 0
           },
           {
             "name": "Green",
-            "value": "1"
+            "value": 1
           },
           {
             "name": "Blue",
-            "value": "2"
+            "value": 2
           }
         ],
         "source_file": "class_positive_test",
@@ -203,8 +199,7 @@
             "name": "shapes",
             "data_type": "Shape",
             "visibility": "private",
-            "is_static": false,
-            "is_const": false
+            "is_static": false
           }
         ],
         "relationships": [
@@ -242,15 +237,13 @@
             "name": "center",
             "data_type": "Point",
             "visibility": "private",
-            "is_static": false,
-            "is_const": false
+            "is_static": false
           },
           {
             "name": "radius",
             "data_type": "f32",
             "visibility": "private",
-            "is_static": false,
-            "is_const": false
+            "is_static": false
           }
         ],
         "relationships": [
@@ -295,15 +288,13 @@
             "name": "origin",
             "data_type": "Point",
             "visibility": "private",
-            "is_static": false,
-            "is_const": false
+            "is_static": false
           },
           {
             "name": "size",
             "data_type": "Size",
             "visibility": "private",
-            "is_static": false,
-            "is_const": false
+            "is_static": false
           }
         ],
         "relationships": [
@@ -339,8 +330,7 @@
             "name": "corner_radius",
             "data_type": "f32",
             "visibility": "private",
-            "is_static": false,
-            "is_const": false
+            "is_static": false
           }
         ],
         "relationships": [
@@ -364,19 +354,19 @@
         "enum_literals": [
           {
             "name": "De",
-            "value": "Debug"
+            "value": 0
           },
           {
             "name": "Info",
-            "value": "Information"
+            "value": 1
           },
           {
             "name": "Warn",
-            "value": "Warnning"
+            "value": 2
           },
           {
             "name": "Err",
-            "value": "Error"
+            "value": 3
           }
         ],
         "source_file": "class_positive_test",

--- a/plantuml/parser/integration_test/class_diagram/class_diagram_relationship_variants/output.json
+++ b/plantuml/parser/integration_test/class_diagram/class_diagram_relationship_variants/output.json
@@ -76,8 +76,7 @@
             "name": "WorkerStatus",
             "data_type": null,
             "visibility": "public",
-            "is_static": false,
-            "is_const": false
+            "is_static": false
           }
         ],
         "relationships": [

--- a/plantuml/parser/integration_test/class_diagram/class_diagram_syntax_coverage/output.json
+++ b/plantuml/parser/integration_test/class_diagram/class_diagram_syntax_coverage/output.json
@@ -198,7 +198,7 @@
         "enum_literals": [
           {
             "name": "kUnspecified",
-            "value": null
+            "value": 0
           }
         ],
         "source_file": "class_diagram_syntax_coverage",
@@ -237,8 +237,7 @@
             "name": "ErrorInfo",
             "data_type": null,
             "visibility": "public",
-            "is_static": false,
-            "is_const": false
+            "is_static": false
           }
         ],
         "relationships": [
@@ -587,15 +586,13 @@
             "name": "config_",
             "data_type": "Config",
             "visibility": "private",
-            "is_static": false,
-            "is_const": false
+            "is_static": false
           },
           {
             "name": "non_fatal_errors",
             "data_type": "{test::result::Error}",
             "visibility": "public",
-            "is_static": false,
-            "is_const": false
+            "is_static": false
           }
         ],
         "relationships": [
@@ -696,8 +693,7 @@
             "name": "",
             "data_type": "std::mutex",
             "visibility": "private",
-            "is_static": false,
-            "is_const": false
+            "is_static": false
           }
         ],
         "relationships": []

--- a/plantuml/parser/puml_resolver/src/class_diagram/src/class_resolver.rs
+++ b/plantuml/parser/puml_resolver/src/class_diagram/src/class_resolver.rs
@@ -490,7 +490,6 @@ impl ClassResolver {
             data_type: attr.r#type.clone(),
             visibility: Self::map_visibility(attr.visibility.clone()),
             is_static: has_modifier(&attr.modifiers, "static"),
-            is_const: has_modifier(&attr.modifiers, "const"),
         }
     }
 
@@ -510,14 +509,17 @@ impl ClassResolver {
             visibility: Self::map_visibility(m.visibility.clone()),
             parameters: m.params.iter().map(Self::convert_param).collect(),
             template_parameters: m.template_parameters.clone(),
-            modifiers: MethodModifier::make_modifier_vec(
-                has_modifier(&m.modifiers, "static"),
-                false,
-                has_modifier(&m.modifiers, "abstract"),
-                false,
-                is_constructor,
-                is_destructor,
-            ),
+            modifiers: MethodModifier::from_conditions([
+                (has_modifier(&m.modifiers, "static"), MethodModifier::Static),
+                (false, MethodModifier::Virtual),
+                (
+                    has_modifier(&m.modifiers, "abstract"),
+                    MethodModifier::Abstract,
+                ),
+                (false, MethodModifier::Override),
+                (is_constructor, MethodModifier::Constructor),
+                (is_destructor, MethodModifier::Destructor),
+            ]),
         }
     }
 
@@ -541,16 +543,28 @@ impl ClassResolver {
     fn process_enum(&mut self, def: &EnumDef, parent: Option<String>) {
         let id = self.build_fqn(&def.name.internal, &parent);
 
+        let mut last_value: Option<i128> = None;
         let literals = def
             .items
             .iter()
-            .map(|item| EnumLiteral {
-                name: item.name.clone(),
-                value: match &item.value {
-                    Some(EnumValue::Literal(v)) => Some(v.clone()),
-                    Some(EnumValue::Description(d)) => Some(d.clone()),
-                    None => None,
-                },
+            .map(|item| {
+                let value = match &item.value {
+                    Some(EnumValue::Literal(v)) => v
+                        .parse::<i128>()
+                        .ok()
+                        .or_else(|| last_value.map(|lv| lv + 1))
+                        .or(Some(0)),
+                    Some(EnumValue::Description(_)) | None => {
+                        last_value.map(|lv| lv + 1).or(Some(0))
+                    }
+                };
+
+                last_value = value;
+
+                EnumLiteral {
+                    name: item.name.clone(),
+                    value,
+                }
             })
             .collect();
 

--- a/plantuml/parser/puml_resolver/src/class_diagram/test/class_resolver_test.rs
+++ b/plantuml/parser/puml_resolver/src/class_diagram/test/class_resolver_test.rs
@@ -101,3 +101,8 @@ fn test_relationship_variants() {
 fn test_syntax_coverage() {
     run_class_resolver_case("class_diagram_syntax_coverage");
 }
+
+#[test]
+fn test_enum_value_sequence() {
+    run_class_resolver_case("class_diagram_enum_value_sequence");
+}

--- a/plantuml/parser/puml_serializer/src/serialize/class_serializer.rs
+++ b/plantuml/parser/puml_serializer/src/serialize/class_serializer.rs
@@ -180,7 +180,6 @@ impl ClassSerializer {
                 data_type: data_type_offset,
                 visibility: Self::map_visibility(variable.visibility),
                 is_static: variable.is_static,
-                is_const: variable.is_const,
             },
         )
     }
@@ -255,10 +254,10 @@ impl ClassSerializer {
         literal: &EnumLiteral,
     ) -> flatbuffers::WIPOffset<fb::EnumLiteral<'a>> {
         let name_offset = builder.create_string(&literal.name);
-        let value_offset = literal
-            .value
-            .as_ref()
-            .map(|value| builder.create_string(value));
+        let value_offset = literal.value.map(|value| {
+            let value = value.to_string();
+            builder.create_string(&value)
+        });
 
         fb::EnumLiteral::create(
             builder,

--- a/tools/metamodel/schema/class_diagram.fbs
+++ b/tools/metamodel/schema/class_diagram.fbs
@@ -62,7 +62,6 @@ table MemberVariable {
     data_type: string;
     visibility: Visibility = Public;
     is_static: bool = false;
-    is_const: bool = false;
 }
 
 table Method {

--- a/tools/metamodel/src/class_logic.rs
+++ b/tools/metamodel/src/class_logic.rs
@@ -20,7 +20,6 @@ pub struct ClassDiagram {
     pub entities: Vec<SimpleEntity>,
     // all relationships in the entire diagram
     pub relationships: Vec<Relationship>, // would make sense inside entities
-
     pub source_files: Vec<String>,
     pub version: Option<String>,
 }
@@ -69,7 +68,6 @@ pub struct SimpleEntity {
     pub source_file: Option<String>,
     /// 1-based line number in source; `None` means the source line is unknown
     pub source_line: Option<u32>,
-    // pub relstionships: Vec<LogicRelationship>, // relationships where this entity is the source
 }
 
 /// The type of entity in a class diagram
@@ -81,12 +79,10 @@ pub enum EntityType {
     Class,
     /// Data structure (typically POD in C++)
     Struct,
-
     /// Abstract interface
     Interface,
     /// Abstract class
     AbstractClass,
-
     /// Enumeration
     Enum,
 }
@@ -125,8 +121,6 @@ pub struct MemberVariable {
     pub visibility: Visibility,
     /// Whether this is a static member
     pub is_static: bool,
-    /// Whether this is a const member
-    pub is_const: bool,
 }
 
 /// Represents a method parameter
@@ -152,34 +146,13 @@ pub enum MethodModifier {
 }
 
 impl MethodModifier {
-    pub fn make_modifier_vec(
-        is_static: bool,
-        is_virtual: bool,
-        is_abstract: bool,
-        is_override: bool,
-        is_constructor: bool,
-        is_destructor: bool,
+    pub fn from_conditions(
+        conditions: impl IntoIterator<Item = (bool, MethodModifier)>,
     ) -> Vec<MethodModifier> {
-        let mut modifiers = Vec::new();
-        if is_static {
-            modifiers.push(MethodModifier::Static);
-        }
-        if is_virtual {
-            modifiers.push(MethodModifier::Virtual);
-        }
-        if is_abstract {
-            modifiers.push(MethodModifier::Abstract);
-        }
-        if is_override {
-            modifiers.push(MethodModifier::Override);
-        }
-        if is_constructor {
-            modifiers.push(MethodModifier::Constructor);
-        }
-        if is_destructor {
-            modifiers.push(MethodModifier::Destructor);
-        }
-        modifiers
+        conditions
+            .into_iter()
+            .filter_map(|(enabled, modifier)| enabled.then_some(modifier))
+            .collect()
     }
 }
 
@@ -242,7 +215,7 @@ pub struct EnumLiteral {
     /// Literal name
     pub name: String,
     /// Explicit value (e.g., `HIGH = 0`)
-    pub value: Option<String>,
+    pub value: Option<i128>,
 }
 
 #[cfg(test)]
@@ -261,7 +234,6 @@ mod tests {
                 data_type: Some("string".to_string()),
                 visibility: Visibility::Public,
                 is_static: false,
-                is_const: false,
             }],
             methods: vec![Method {
                 name: "getName".to_string(),

--- a/validation/core/src/readers/class_diagram_reader.rs
+++ b/validation/core/src/readers/class_diagram_reader.rs
@@ -65,7 +65,6 @@ fn read_variables(
                             &format!("{path}:entity:{}:variable:{}", entity.id(), value.name()),
                         )?,
                         is_static: value.is_static(),
-                        is_const: value.is_const(),
                     })
                 })
                 .collect::<Result<Vec<_>, String>>()
@@ -144,7 +143,7 @@ fn read_enum_literals(entity: fb_class::SimpleEntity<'_>) -> Vec<EnumLiteral> {
                 .iter()
                 .map(|value| EnumLiteral {
                     name: value.name().to_string(),
-                    value: value.value().map(|s| s.to_string()),
+                    value: value.value().and_then(|s| s.parse::<i128>().ok()),
                 })
                 .collect::<Vec<_>>()
         })


### PR DESCRIPTION
- Refactor:
  - Enum literals in serialized outputs are now numeric integers; explicit values are preserved and unspecified entries auto-sequence (starting from 0).
  - Const-qualified flag for member variables removed from serialized metadata; static flags remain.
  - Method modifier determination improved for more accurate modifier classification (static/virtual/abstract/override/constructor/destructor).
- Tests:
Integration fixtures updated and a new test added to cover revised enum value sequencing and member-variable serialization.