### PR TITLE
fix: Remove Android SDK dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -284,9 +284,9 @@ bazel_dep(name = "googletest", version = "1.17.0.bcr.2", dev_dependency = True)
 ###############################################################################
 # Blueprint Maven
 ###############################################################################
-bazel_dep(name = "rules_jvm_external", version = "6.10")
+bazel_dep(name = "rules_jvm_external", version = "6.10", dev_dependency = True)
 
-maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven", dev_dependency = True)
 maven.install(
     name = "blueprint_maven_dependencies",
     artifacts = [

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -284,9 +284,14 @@ bazel_dep(name = "googletest", version = "1.17.0.bcr.2", dev_dependency = True)
 ###############################################################################
 # Blueprint Maven
 ###############################################################################
-bazel_dep(name = "rules_jvm_external", version = "6.10", dev_dependency = True)
+# WARNING: rules_jvm_external 6.10 depends on the Android SDK, which is removed
+#          from Github Actions runners by https://github.com/eclipse-score/more-disk-space
+#          When upgrading rules_jvm_external, make sure to check if the Android
+#          SDK is still required and if so, add it back to the Github Actions
+#          runners.
+bazel_dep(name = "rules_jvm_external", version = "6.9")
 
-maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven", dev_dependency = True)
+maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(
     name = "blueprint_maven_dependencies",
     artifacts = [


### PR DESCRIPTION
rules_jvm_external introduces an Android SDK dependency to the QNX build as can be seen with https://github.com/eclipse-score/inc_someip_gateway/pull/164, where the build is fixed. By default an Android SDK is present on the runners, except when [more-disk-space](https://github.com/eclipse-score/more-disk-space) is used, which is here the case.

The downgrade to an earlier version removes it for the time being.

It is also unclear to me why only in CI the Android SDK dependency is present.