### PR TITLE
fix(rules_score): correct submodule doc link path

### DIFF
--- a/bazel/rules/rules_score/private/dependable_element.bzl
+++ b/bazel/rules/rules_score/private/dependable_element.bzl
@@ -109,6 +109,9 @@ _COMPONENT_TEMPLATE = """
 
 {requirements_section}{units_section}{implementation_section}{tests_section}"""
 
+# Suffix used by dependable_element to name the internal sphinx_module target.
+_DOC_TARGET_SUFFIX = "_doc"
+
 # ============================================================================
 # Integrity Level Definitions
 # ============================================================================
@@ -359,11 +362,19 @@ def _process_deps(ctx):
     for dep in ctx.attr.deps:
         dep_name = dep.label.name
 
-        # Create a link to the index.html that will be merged
-        # Format: * `Module Name <module_name/index.html>`_
+        # Create a link to the merged HTML index directory.
+        # The merge step uses the sphinx_module target label name as directory,
+        # i.e. "<module_name>" + _DOC_TARGET_SUFFIX for dependable_element deps.
         # Use underscores in name for readability, convert to spaces for display
         display_name = dep_name.replace("_", " ").title()
-        links.append("* `{} <{}/index.html>`_".format(display_name, dep_name))
+        links.append(
+            "* `{} <{}{}{}>`_".format(
+                display_name,
+                dep_name,
+                _DOC_TARGET_SUFFIX,
+                "/index.html",
+            ),
+        )
 
     return "\n".join(links)
 
@@ -1425,7 +1436,7 @@ def dependable_element(
         name = name + "_doc",
         srcs = [":" + name + "_index"],
         index = ":" + name + "_index",
-        deps = [d + "_doc" for d in deps],
+        deps = [d + _DOC_TARGET_SUFFIX for d in deps],
         sphinx = sphinx,
         testonly = testonly,
         **kwargs

--- a/bazel/rules/rules_score/test/BUILD
+++ b/bazel/rules/rules_score/test/BUILD
@@ -529,6 +529,14 @@ seooc_artifacts_copied_test(
     target_under_test = ":seooc_test_lib_index",
 )
 
+# Regression test: generated submodule links must point to <dep>_doc/index.html.
+sh_test(
+    name = "seooc_tests_dep_links_use_doc_dir",
+    srcs = ["check_seooc_dep_links.sh"],
+    args = ["$(rootpaths :seooc_test_lib_index)"],
+    data = [":seooc_test_lib_index"],
+)
+
 # Test that sphinx_module is generated with correct providers
 seooc_sphinx_module_generated_test(
     name = "seooc_tests_sphinx_module_generated",
@@ -633,6 +641,7 @@ test_suite(
     tests = [
         ":seooc_tests_all_sources_relocated",
         ":seooc_tests_artifacts_copied",
+        ":seooc_tests_dep_links_use_doc_dir",
         ":seooc_tests_index_file_provider",
         ":seooc_tests_index_generation",
         ":seooc_tests_multi_index_files_exist",

--- a/bazel/rules/rules_score/test/check_seooc_dep_links.sh
+++ b/bazel/rules/rules_score/test/check_seooc_dep_links.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+set -euo pipefail
+
+index_file=""
+for rel_path in "$@"; do
+    candidate="${TEST_SRCDIR}/${TEST_WORKSPACE}/${rel_path}"
+    if [[ -f "${candidate}" && "${candidate}" == */index.rst ]]; then
+        index_file="${candidate}"
+        break
+    fi
+done
+
+if [[ -z "${index_file}" ]]; then
+    echo "Error: Could not locate index.rst in provided runfiles paths: $*" >&2
+    exit 1
+fi
+
+if ! grep -Fq '* `Dep Seooc Lib <dep_seooc_lib_doc/index.html>`_' "${index_file}"; then
+    echo "Error: expected submodule link to dep_seooc_lib_doc/index.html in ${index_file}" >&2
+    exit 1
+fi
+
+echo "ok"


### PR DESCRIPTION
## Summary

- fix generated submodule links in `dependable_element.bzl` to point to `<dep>_doc/index.html`
- remove duplicated `"_doc"` literals by introducing and reusing `_DOC_TARGET_SUFFIX`
- add regression coverage for generated dependency links (`seooc_tests_dep_links_use_doc_dir`)
- fix the regression test wiring and assertion format:
  - use `$(rootpaths :seooc_test_lib_index)` for multi-output target inputs
  - match emitted backtick-based RST link syntax in `index.rst`

## Validation

- `buildifier -mode=check bazel/rules/rules_score/private/dependable_element.bzl bazel/rules/rules_score/test/BUILD`
- `bazel test //:format.check`
- `bazel build //bazel/rules/rules_score/examples/seooc:safety_software_seooc_example_index`

## Validation notes

- `buildifier` passed for touched Starlark files
- `bazel test //:format.check` passed
- example build could not be completed locally because `pycairo==1.29.0` failed to build in this environment (missing `pkg-config`/cairo tooling) during external dependency resolution